### PR TITLE
feat : Status 제거, cursor 추가

### DIFF
--- a/src/main/java/org/example/lifechart/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/org/example/lifechart/domain/notification/dto/NotificationResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.example.lifechart.domain.notification.entity.Notification;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,12 +12,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class NotificationResponseDto {
 	private Long id;
 
 	private Notification.Type type;
-
-	private Notification.Status status;
 
 	private String title;
 
@@ -24,12 +24,14 @@ public class NotificationResponseDto {
 
 	private LocalDateTime completedAt;
 
+	private LocalDateTime requestedAt;
+
 	public NotificationResponseDto(Notification n){
 		this.id = n.getId();
 		this.type = n.getType();
-		this.status = n.getStatus();
 		this.title = n.getTitle();
 		this.message = n.getMessage();
 		this.completedAt = n.getCompletedAt();
+		this.requestedAt = n.getRequestedAt();
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/notification/entity/Notification.java
+++ b/src/main/java/org/example/lifechart/domain/notification/entity/Notification.java
@@ -29,9 +29,6 @@ public class Notification {
 	@Enumerated(EnumType.STRING)
 	private Type type;
 
-	@Enumerated(EnumType.STRING)
-	private Status status;
-
 	private String title;
 
 	private String message;
@@ -52,7 +49,6 @@ public class Notification {
 		this.title = dto.getTitle();
 		this.message = dto.getMessage();
 		this.processedAt = LocalDateTime.now();
-		this.status = Status.UNREAD;
 	}
 
 	public String getEventId() {
@@ -66,7 +62,4 @@ public class Notification {
 		NOTICE, EMAIL, USER_NOTIFICATION
 	}
 
-	public enum Status {
-		FAILED, UNREAD, READ
-	}
 }

--- a/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepository.java
@@ -10,8 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
-	List<Notification> findTop20ByUserIdOrderByRequestedAtDesc(Long userId);
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE Notification n SET n.completedAt=:now WHERE n.userId = :userId AND n.completedAt IS NULL")

--- a/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.example.lifechart.domain.notification.repository;
+
+import java.util.List;
+
+import org.example.lifechart.domain.notification.dto.NotificationResponseDto;
+
+public interface NotificationRepositoryCustom {
+
+	List<NotificationResponseDto> getList(Long userId, Long cursor, int size);
+}

--- a/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/org/example/lifechart/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,33 @@
+package org.example.lifechart.domain.notification.repository;
+
+import java.util.List;
+
+import org.example.lifechart.domain.notification.dto.NotificationResponseDto;
+import org.example.lifechart.domain.notification.entity.Notification;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Override
+	@Transactional
+	public List<NotificationResponseDto> getList(Long userId, Long cursor, int size) {
+
+		List<NotificationResponseDto> result = em.createQuery(
+			"SELECT new org.example.lifechart.domain.notification.dto.NotificationResponseDto(n.id, n.type, n.title, n.message, n.completedAt, n.requestedAt) "
+				+ "FROM Notification n WHERE n.id <= :cursor AND n.userId = :userId ORDER BY n.id DESC", NotificationResponseDto.class
+		).setParameter("userId", userId)
+			.setParameter("cursor", cursor)
+			.setMaxResults(size)
+			.getResultList();
+
+		return result;
+	}
+}

--- a/src/main/java/org/example/lifechart/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/lifechart/domain/notification/service/NotificationService.java
@@ -21,13 +21,13 @@ public class NotificationService {
 
 	@Transactional
 	public List<NotificationResponseDto> getList(
-		Long cursor, Long userId
+		Long userId, Long cursor, int size
 	) {
-		return notificationRepo.findTop20ByUserIdOrderByRequestedAtDesc(
-				userId)
-			.stream()
-			.map(NotificationResponseDto::new)
-			.toList();
+		if(cursor == null) cursor = Long.MAX_VALUE;
+		if(size > 20) size = 20;
+
+		return notificationRepo.getList(
+				userId, cursor, size);
 	}
 
 	@Transactional
@@ -45,7 +45,7 @@ public class NotificationService {
 				() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND)
 			);
 
-		if(!Objects.equals(n.getUserId(), userId)){
+		if (!Objects.equals(n.getUserId(), userId)) {
 			throw new CustomException(ErrorCode.NOTIFICATION_PERMISSION);
 		}
 


### PR DESCRIPTION

## ✨ 변경 사항
- Notification.status 제거 
상태는 processedAt, completedAt으로 확인 가능.
실패는 별도로 처리 & 보관 예정

- Notification 조회 시 cursor 추가

- 회원 본인의 Notification 추가하는 API 추가

## 📷 Postman 
<img src="https://github.com/user-attachments/assets/0b8a3c7a-5cea-481f-b173-31b19dd476ac" width=400px/>

<img src="https://github.com/user-attachments/assets/f3b51b68-ae45-4000-974c-e8fb0545aaa1" width=300px/>


## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
