### PR TITLE
[test] Simulation 테스트코드 추가

### DIFF
--- a/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.lifechart.common.enums.SuccessCode;
 import org.example.lifechart.common.response.ApiResponse;
 import org.example.lifechart.domain.simulation.dto.request.BaseCreateSimulationRequestDto;
+import org.example.lifechart.domain.simulation.dto.response.BaseSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.CreateSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.DeletedSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.SimulationSummaryDto;
@@ -49,20 +50,20 @@ public class SimulationController {
     }
 
     //시뮬레이션 상세 조회 로직
-//    @Operation(summary = "시뮬레이션 상세 조회", description = "시뮬레이션 ID로 상세 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
-//    @GetMapping("/simulations/{simulationId}")
-//    public ResponseEntity<BaseSimulationResponseDto> getSimulation(@AuthenticationPrincipal CustomUserPrincipal principal,@PathVariable Long simulationId) {
-//        BaseSimulationResponseDto simulation = simulationService.findSimulationById(principal, simulationId);
-//        return ResponseEntity.ok(simulation);
-//    }
-//
+    @Operation(summary = "시뮬레이션 상세 조회", description = "시뮬레이션 ID로 상세 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @GetMapping("/simulations/{simulationId}")
+    public ResponseEntity<BaseSimulationResponseDto> getSimulation(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long simulationId) {
+        BaseSimulationResponseDto simulation = simulationService.findSimulationById(principal.getUserId(), simulationId);
+        return ResponseEntity.ok(simulation);
+    }
+
     //시뮬레이션 softdelete내역 조회 로직
-//    @Operation(summary = "시뮬레이션 softdelete 삭제된 내역들 조회", description = "시뮬레이션 ID로 삭제된 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
-//    @GetMapping("/simulations/deleted")
-//    public ResponseEntity<ApiResponse<List<DeletedSimulationResponseDto>>> getSoftSimulation(@AuthenticationPrincipal CustomUserPrincipal principal) {
-//        List<DeletedSimulationResponseDto> simulations = simulationService.findAllSoftDeletedSimulations(principal.getUserId());
-//        return ApiResponse.onSuccess(SuccessCode.SIMULATION_GET_DELETED_LIST_SUCCESS, simulations);
-//    }
+    @Operation(summary = "시뮬레이션 softdelete 삭제된 내역들 조회", description = "시뮬레이션 ID로 삭제된 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+    @GetMapping("/simulations/deleted")
+    public ResponseEntity<ApiResponse<List<DeletedSimulationResponseDto>>> getSoftSimulation(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        List<DeletedSimulationResponseDto> simulations = simulationService.findAllSoftDeletedSimulations(principal.getUserId());
+        return ApiResponse.onSuccess(SuccessCode.SIMULATION_GET_DELETED_LIST_SUCCESS, simulations);
+    }
 
     //업데이트 로직은 컨트롤러 추후 수정필요.
 //    @Operation(summary = "시뮬레이션 업데이트", description = "시뮬레이션을 업데이트합니다.", security = @SecurityRequirement(name = "bearerAuth"))

--- a/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
@@ -52,9 +52,9 @@ public class SimulationController {
     //시뮬레이션 상세 조회 로직
     @Operation(summary = "시뮬레이션 상세 조회", description = "시뮬레이션 ID로 상세 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping("/simulations/{simulationId}")
-    public ResponseEntity<BaseSimulationResponseDto> getSimulation(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long simulationId) {
-        BaseSimulationResponseDto simulation = simulationService.findSimulationById(principal.getUserId(), simulationId);
-        return ResponseEntity.ok(simulation);
+    public ResponseEntity<ApiResponse<BaseSimulationResponseDto>> getSimulation(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long simulationId) {
+        BaseSimulationResponseDto simulation = simulationService.findSimulationByUsserIdAndSimulationId(principal.getUserId(), simulationId);
+        return ApiResponse.onSuccess(SuccessCode.SIMULATION_GET_LIST_SUCCESS, simulation);
     }
 
     //시뮬레이션 softdelete내역 조회 로직

--- a/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
@@ -53,7 +53,7 @@ public class SimulationController {
     @Operation(summary = "시뮬레이션 상세 조회", description = "시뮬레이션 ID로 상세 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping("/simulations/{simulationId}")
     public ResponseEntity<ApiResponse<BaseSimulationResponseDto>> getSimulation(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long simulationId) {
-        BaseSimulationResponseDto simulation = simulationService.findSimulationByUsserIdAndSimulationId(principal.getUserId(), simulationId);
+        BaseSimulationResponseDto simulation = simulationService.findSimulationByUserIdAndSimulationId(principal.getUserId(), simulationId);
         return ApiResponse.onSuccess(SuccessCode.SIMULATION_GET_LIST_SUCCESS, simulation);
     }
 

--- a/src/main/java/org/example/lifechart/domain/simulation/dto/response/BaseSimulationResponseDto.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/dto/response/BaseSimulationResponseDto.java
@@ -6,6 +6,7 @@ import org.example.lifechart.domain.simulation.entity.Simulation;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -56,41 +57,23 @@ public class BaseSimulationResponseDto {
     //매달 자산 가격 변화
     private List<MonthlyAssetDto> monthlyAssets;
 
-    //시뮬레이션 생성에 필요한 정적팩토리메서드
-    public static BaseSimulationResponseDto of(
-            Simulation simulation,
-            List<Long> goalIds,
-            SimulationResults results
-    ) {
-        return BaseSimulationResponseDto.builder()
-                .simulationId(simulation.getId())
-                .userNickname(simulation.getUser().getNickname())
-                .title(simulation.getTitle())
-                .baseDate(simulation.getBaseDate())
-                .goalIds(goalIds)
-                .requiredAmount(results.getRequiredAmount())
-                .monthsToGoal(results.getMonthsToGoal())
-                .currentAchievementRate(results.getCurrentAchievementRate())
-                .monthlyAchievements(results.getMonthlyAchievements())
-                .monthlyAssets(results.getMonthlyAssets())
-                .build();
-    }
-
-    //이건 조회할 때 필요.
+    //이건 조회시.
     public static BaseSimulationResponseDto dto(
-            Simulation simulation,
-            SimulationResults results
+            Simulation simulation
     ) {
         return BaseSimulationResponseDto.builder()
                 .simulationId(simulation.getId())
+                .goalIds(simulation.getSimulationGoals().stream()
+                        .map(simGoal -> simGoal.getGoal().getId())
+                        .collect(Collectors.toList()))
                 .userNickname(simulation.getUser().getNickname())
                 .title(simulation.getTitle())
                 .baseDate(simulation.getBaseDate())
-                .requiredAmount(results.getRequiredAmount())
-                .monthsToGoal(results.getMonthsToGoal())
-                .currentAchievementRate(results.getCurrentAchievementRate())
-                .monthlyAchievements(results.getMonthlyAchievements())
-                .monthlyAssets(results.getMonthlyAssets())
+                .requiredAmount(simulation.getRequiredAmount())
+                .monthsToGoal(simulation.getMonthsToGoal())
+                .currentAchievementRate(simulation.getCurrentAchievementRate())
+                .monthlyAchievements(simulation.getMonthlyAchievements())
+                .monthlyAssets(simulation.getMonthlyAssets())
                 .build();
     }
 

--- a/src/main/java/org/example/lifechart/domain/simulation/repository/SimulationRepository.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/repository/SimulationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +26,7 @@ public interface SimulationRepository extends JpaRepository<Simulation, Long> {
     @Query("SELECT g FROM Goal g WHERE g.id IN :goalIds AND g.user.id = :userId")
     List<Goal> findAllByIdAndUserId(@Param("goalIds") List<Long> goalIds, @Param("userId") Long userId);
 
-    //@Query("SELECT s FROM Simulation s WHERE s.user.id = :userId AND s.isDeleted = true")
-    //List<Simulation> findAllByUserIdAndIsDeletedTrue(@Param("userId") Long userId);
+    @Query("SELECT s FROM Simulation s WHERE s.user.id = :userId AND s.isDeleted = true")
+    List<Simulation> findAllByUserIdAndIsDeletedTrue(@Param("userId") Long userId);
 
 }

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
@@ -3,6 +3,7 @@ package org.example.lifechart.domain.simulation.service.simulation;
 //readonly주의할 것.
 
 import org.example.lifechart.domain.simulation.dto.request.BaseCreateSimulationRequestDto;
+import org.example.lifechart.domain.simulation.dto.response.BaseSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.CreateSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.DeletedSimulationResponseDto;
 import org.example.lifechart.domain.simulation.dto.response.SimulationSummaryDto;
@@ -12,8 +13,8 @@ import java.util.List;
 public interface SimulationService {
      CreateSimulationResponseDto saveSimulation(BaseCreateSimulationRequestDto dto, Long userId, List<Long> goalIds);
      List<SimulationSummaryDto> findAllSimulationsByUserId(Long userId);
-//    BaseSimulationResponseDto findSimulationById(User user, Long simulationId);
-//    List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId);
+     BaseSimulationResponseDto findSimulationById(Long userId, Long simulationId);
+     List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId);
       DeletedSimulationResponseDto softDeleteSimulation(Long userId, Long simulationId);
       void deleteSimulation(Long userId, Long simulationId);
 //    SimulationResponseDto updateSimulation(SimulationResponseDto simulationResponseDto);

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface SimulationService {
      CreateSimulationResponseDto saveSimulation(BaseCreateSimulationRequestDto dto, Long userId, List<Long> goalIds);
      List<SimulationSummaryDto> findAllSimulationsByUserId(Long userId);
-     BaseSimulationResponseDto findSimulationByUsserIdAndSimulationId(Long userId, Long simulationId);
+     BaseSimulationResponseDto findSimulationByUserIdAndSimulationId(Long userId, Long simulationId);
      List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId);
       DeletedSimulationResponseDto softDeleteSimulation(Long userId, Long simulationId);
       void deleteSimulation(Long userId, Long simulationId);

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationService.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface SimulationService {
      CreateSimulationResponseDto saveSimulation(BaseCreateSimulationRequestDto dto, Long userId, List<Long> goalIds);
      List<SimulationSummaryDto> findAllSimulationsByUserId(Long userId);
-     BaseSimulationResponseDto findSimulationById(Long userId, Long simulationId);
+     BaseSimulationResponseDto findSimulationByUsserIdAndSimulationId(Long userId, Long simulationId);
      List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId);
       DeletedSimulationResponseDto softDeleteSimulation(Long userId, Long simulationId);
       void deleteSimulation(Long userId, Long simulationId);

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
@@ -125,7 +125,7 @@ public class SimulationServiceImpl implements SimulationService {
 
     //id에 해당하는 단건 조회.
     @Transactional(readOnly = true)
-    public BaseSimulationResponseDto findSimulationByUsserIdAndSimulationId(Long userId, Long simulationId) {
+    public BaseSimulationResponseDto findSimulationByUserIdAndSimulationId(Long userId, Long simulationId) {
 
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
@@ -5,13 +5,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
+import org.example.lifechart.domain.goal.dto.request.GoalUpdateRequest;
+import org.example.lifechart.domain.goal.dto.response.GoalResponse;
 import org.example.lifechart.domain.goal.entity.Goal;
 import org.example.lifechart.domain.goal.repository.GoalRepository;
+import org.example.lifechart.domain.goal.service.GoalService;
 import org.example.lifechart.domain.simulation.dto.request.BaseCreateSimulationRequestDto;
-import org.example.lifechart.domain.simulation.dto.response.CreateSimulationResponseDto;
-import org.example.lifechart.domain.simulation.dto.response.DeletedSimulationResponseDto;
-import org.example.lifechart.domain.simulation.dto.response.SimulationResults;
-import org.example.lifechart.domain.simulation.dto.response.SimulationSummaryDto;
+import org.example.lifechart.domain.simulation.dto.response.*;
 import org.example.lifechart.domain.simulation.entity.Simulation;
 import org.example.lifechart.domain.simulation.entity.SimulationGoal;
 import org.example.lifechart.domain.simulation.repository.SimulationGoalJdbcRepository;
@@ -40,6 +40,7 @@ public class SimulationServiceImpl implements SimulationService {
     private final UserRepository userRepository;
     private final SimulationGoalRepository simulationGoalRepository;
     private final CalculateAll calculateAll;
+    private final GoalService goalService;
 
     //사용자가 목표는 그대로 두고, 시뮬레이션만 새로운 파라미터로 돌림
     @Transactional
@@ -52,7 +53,6 @@ public class SimulationServiceImpl implements SimulationService {
 
         // 1. Goal 목록 조회하면서 user도 같이 갖고옴.
         List<Goal> goals = goalRepository.findAllWithUserByIdAndUserId(goalIds, userId);
-
 
         // 2. 존재하지 않는 goalId 검증
         if (goals.size() != goalIds.size()) {
@@ -84,10 +84,8 @@ public class SimulationServiceImpl implements SimulationService {
         //-매달 자산 변화
         Simulation simulation = Simulation.createSimulation(dto, results, user);
 
-
         //6. simulationGoal생성시 simulation.getId가 필요
         simulationRepository.save(simulation);
-
 
         //7. 수정: Goal리스트를 Map으로 변환하고 key는 goalid, value는 goal객체 자체.
         //map key로 goal의 id값이 들어가도록 반환.
@@ -132,66 +130,107 @@ public class SimulationServiceImpl implements SimulationService {
 
     }
 
+    //id에 해당하는 단건 조회.
+    @Transactional(readOnly = true)
+    public BaseSimulationResponseDto findSimulationById(Long userId, Long simulationId) {
 
-//    //id에 해당하는 단건 조회. 어떤 필드만 보여줘야할지 dto를 다시 세팅해야 할듯.
-//    //패치조인으로..
-//    public BaseSimulationResponseDto findSimulationById(User user , Long simulationId) {
-//
-//        //커스텀예외처리 필요
-//        Simulation simulation = simulationRepository.findByIdWithResults(simulationId)
-//                .orElseThrow(() -> new CustomException(ErrorCode.SIMULATION_NOT_FOUND));
-//
-//        if (!simulation.getUser().getId().equals(user.getId())) {
-//            throw new CustomException(ErrorCode.SIMULATION_BAD_REQUEST);
-//        }
-//
-//        SimulationResults results = simulation.getResults();
-//
-//        return BaseSimulationResponseDto.dto(simulation, results);
-//    }
+        User user = userRepository.findById(userId)
+                .filter(u -> !u.getIsDeleted())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-//    @Transactional(readOnly = true)
-//    public List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId) {
-//
-//        List<Simulation> deletedSimulations = simulationRepository.findAllByUserIdAndIsDeletedTrue(userId);
-//
-//        return deletedSimulations.stream()
-//                .map(DeletedSimulationResponseDto::toDto)
-//                .collect(Collectors.toList());
-//    }
+        Simulation simulation = simulationRepository.findById(simulationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SIMULATION_NOT_FOUND));
+
+        if (!simulation.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.SIMULATION_BAD_REQUEST);
+        }
+
+        return BaseSimulationResponseDto.dto(simulation);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<DeletedSimulationResponseDto> findAllSoftDeletedSimulations(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getIsDeleted()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        List<Simulation> deletedSimulations = simulationRepository.findAllByUserIdAndIsDeletedTrue(userId);
+
+        return deletedSimulations.stream()
+                .map(DeletedSimulationResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+
 
 //    수정로직
-//    @Transactional
-//    public BaseSimulationResponseDto updateSimulation(List<SimulationGoal> newSimulationGoals,Simulation simulation) {
-//        // 1. goal이 목표 수정했는지  -> 목표가 수정되면 목표 ID를 확보함. 업데이트된 골을 service메서드에서 dto값을 가져옴.
-//        Goal updateGoal = goalService.updateGoal(goalUpdateDto);
+    @Transactional
+    public BaseSimulationResponseDto updateSimulation(BaseCreateSimulationRequestDto dto,
+                                                      List<SimulationGoal> newSimulationGoals,
+                                                      Simulation simulation,
+                                                      GoalUpdateRequest goalUpdateRequest,
+                                                      Long goalId,
+
+                                                      Long userId) {
+
+        //유저 정보
+        //연결되어있는 목표 시뮬레이션도 바꿀 수 잇음 . 입력값 파라미터를 시뮬레이션
+        //골이 업데이트되면  시뮬레이션이 바뀔 수가 있음.
+        //
+
+        //시뮬레이션 안에서 목표를 수정하는 흐름. 시뮬레이션은
+        //목표 도메인 updateGoal업데이트반영되면 시뮬레이션골이 goal이 담고있음.
+        //연결되는 목표id로 업데이트된게 반영 목표가 수정됐을 때 시뮬레이션 업데이트 ㅎ르므 . 시뮬에ㅣ션 업데이트서비스로직에
+        //기존 목표 연결 비활성화
+
+        // 1. goal이 목표 수정했는지  -> 목표가 수정되면 목표 ID를 확보함. 업데이트된 골을 service메서드에서 dto값을 가져옴.
+        GoalResponse updatedGoalResponse = goalService.updateGoal(goalUpdateRequest, goalId, userId);
+
+        Long updatedGoalId = updatedGoalResponse.getGoalId();
+
+        //2. 수정된 목표가 연결된 시뮬레이션 조회 goalId에 연결된 시뮬레이션이 여러개일 수도 있음 -> 가져올 때 중복 제거
+        List<Simulation> simulations = simulationGoalRepository.findDistinctSimulationsByGoalId(goalId);
+
+        //3. 수정된 Goal엔티티 조회
+        Goal updateGoal = goalRepository.findById(updatedGoalId)
+                .orElseThrow(()-> new CustomException(ErrorCode.GOAL_NOT_FOUND));
+        List<Goal> updateGoals = List.of(updateGoal);
+
+
+
+
+
+        //4. 각 시뮬레이션에 대해 재계산
+        //수정: Goal리스트를 Map으로 변환하고 key는 goalid, value는 goal객체 자체.
+        Map<Long, Goal> goalMap = updateGoals.stream()
+                .collect(Collectors.toMap(Goal::getId, Function.identity()));
+
+        //
+            //5. 시뮬레이션과 시뮬레이션 골 사이의 연관관계 재설정.
+            //시뮬레이션 수정 흐름 설계 중에 기존 Simulation에 연결된 SimulationGoal들이 존재.
+            //업데이트하는 로직에서도 필드를 같이 관리 해야함.
+        //goalId에 연결된 모든 Simulation을 확인해봐야함.
+        //시뮬레이션은 현재 목표와 바꾸고싶은 목표를 시뮬레이션 해서 보여줄 수 있다.
+//        SimulationResults results = calculateAll.calculate(
+//                dto.getInitialAsset(),
+//                dto.getMonthlyIncome(),
+//                dto.getMonthlyExpense(),
+//                dto.getMonthlySaving(),
+//                dto.getAnnualInterestRate(),
+//                dto.getElapsedMonths(),
+//                dto.getTotalMonths(),
+//                dto.getBaseDate(),
+//                goalId1
+//        );
+//        simulation.updateResults(results);
 //
-//        //goalId필요함.(선택한 goal이 무엇인지..)
-//        Long goalId = updateGoal.getId();
-//
-//        //2. 수정된 목표가 연결된 시뮬레이션 조회 goalId에 연결된 시뮬레이션이 여러개일 수도 있음 -> 가져올 때 중복 제거
-//        List<Simulation> simulations = simulationGoalRepository.findDistinctSimulationsByGoalId(goalId);
-//
-//        //3. 각 시뮬레이션에 대해 재계산
-//        //수정: Goal리스트를 Map으로 변환하고 key는 goalid, value는 goal객체 자체.
-//        //map key로 goal의 id값이 들어가도록 반환하면
-//        Map<Long, Goal> goalMap = goals.stream()
-//                .collect(Collectors.toMap(Goal::getId, Function.identity()));
-//
-//            //5. 시뮬레이션과 시뮬레이션 골 사이의 연관관계 재설정.
-//            //시뮬레이션 수정 흐름 설계 중에 기존 Simulation에 연결된 SimulationGoal들이 존재.
-//            //업데이트하는 로직에서도 필드를 같이 관리 해야함.
-//        //goalId에 연결된 모든 Simulation을 확인해봐야함.
-//        for(Simulation updateSimulation : simulations) {
-//            simulationGoalJdbcRepository.deactivateSimulationGoals(updateSimulation.getId());
-//        }
-//            simulationGoalJdbcRepository.batchInsertSimulationGoals(newSimulationGoals);
-//
-//        //시뮬레이션은 현재 목표와 바꾸고싶은 목표를 시뮬레이션 해서 보여줄 수 있다.
-//
-//        return BaseSimulationResponseDto.toDto(simulation);
-//
-//    }
+        return BaseSimulationResponseDto.dto(simulation);
+
+    }
 //    어떤 목표랑 연결되어있는지, 시뮬레이션 하나에 복수 목표를 가지고 있지 않은지 판단하는 로직 필요.
 
 
@@ -228,10 +267,14 @@ public class SimulationServiceImpl implements SimulationService {
     @Transactional
     public void deleteSimulation(Long userId, Long simulationId) {
 
+        User user = userRepository.findById(userId)
+                .filter(u -> !u.getIsDeleted())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         Simulation simulation = simulationRepository.findById(simulationId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SIMULATION_NOT_FOUND));
 
-        if (!simulation.getUser().getId().equals(userId)) {
+        if (!simulation.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.SIMULATION_BAD_REQUEST);
         }
 

--- a/src/test/java/org/example/lifechart/domain/simulation/SimulationCalculatorTest.java
+++ b/src/test/java/org/example/lifechart/domain/simulation/SimulationCalculatorTest.java
@@ -1,4 +1,4 @@
-package org.example.lifechart.simulation;
+package org.example.lifechart.domain.simulation;
 
 import org.example.lifechart.domain.goal.entity.Goal;
 import org.example.lifechart.domain.simulation.dto.response.MonthlyAchievement;

--- a/src/test/java/org/example/lifechart/domain/simulation/SimulationServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/domain/simulation/SimulationServiceImplTest.java
@@ -1,4 +1,4 @@
-package org.example.lifechart.simulation;
+package org.example.lifechart.domain.simulation;
 
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
@@ -338,7 +338,7 @@ public class SimulationServiceImplTest {
         given(simulationRepository.findById(1L)).willReturn(Optional.of(simulation));
 
         //유저랑 simulationId랑 같은지 확인하는 것은 예외 검증테스트 로직으로 관리해야 함.
-        BaseSimulationResponseDto simulationResponseDto = simulationService.findSimulationByUsserIdAndSimulationId(user2.getId(), simulation.getId());
+        BaseSimulationResponseDto simulationResponseDto = simulationService.findSimulationByUserIdAndSimulationId(user2.getId(), simulation.getId());
 
         //검증은 값이 잘 조회되는지 나오는지.
         assertThat(simulationResponseDto).isNotNull();
@@ -367,7 +367,7 @@ public class SimulationServiceImplTest {
         given(simulationRepository.findById(simulationId)).willReturn(Optional.of(simulation));
 
         CustomException ex = assertThrows(CustomException.class, () -> {
-            simulationService.findSimulationByUsserIdAndSimulationId(userId, simulationId);
+            simulationService.findSimulationByUserIdAndSimulationId(userId, simulationId);
         });
 
         assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SIMULATION_BAD_REQUEST);

--- a/src/test/java/org/example/lifechart/simulation/SimulationServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/simulation/SimulationServiceImplTest.java
@@ -1,19 +1,45 @@
 package org.example.lifechart.simulation;
 
+import org.example.lifechart.common.enums.ErrorCode;
+import org.example.lifechart.common.exception.CustomException;
+import org.example.lifechart.domain.goal.entity.Goal;
+import org.example.lifechart.domain.goal.enums.Category;
+import org.example.lifechart.domain.goal.enums.Share;
+import org.example.lifechart.domain.goal.enums.Status;
 import org.example.lifechart.domain.goal.repository.GoalRepository;
-import org.example.lifechart.domain.simulation.repository.SimulationGoalJdbcRepository;
+import org.example.lifechart.domain.simulation.dto.request.BaseCreateSimulationRequestDto;
+import org.example.lifechart.domain.simulation.dto.response.*;
+import org.example.lifechart.domain.simulation.entity.Simulation;
+import org.example.lifechart.domain.simulation.entity.SimulationGoal;
 import org.example.lifechart.domain.simulation.repository.SimulationGoalRepository;
 import org.example.lifechart.domain.simulation.repository.SimulationRepository;
 import org.example.lifechart.domain.simulation.service.calculator.CalculateAll;
 import org.example.lifechart.domain.simulation.service.calculator.SimulationCalculator;
 import org.example.lifechart.domain.simulation.service.simulation.SimulationServiceImpl;
 import org.example.lifechart.domain.simulation.service.simulation.SimulationValidator;
+import org.example.lifechart.domain.user.entity.User;
 import org.example.lifechart.domain.user.repository.UserRepository;
 import org.example.lifechart.domain.user.service.UserServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -42,162 +68,92 @@ public class SimulationServiceImplTest {
     private GoalRepository goalRepository;
 
     @Mock
-    private SimulationGoalJdbcRepository simulationGoalJdbcRepository;
-
-    @Mock
     private CalculateAll calculateAll;
 
-    @Mock
-    private SimulationCalculator calculator;
 
-//    @Test
-//    @DisplayName("사용자 id로 Simulation 전체 목록 조회 성공")
-//    void 사용자_id로_Simulation_전체_목록_조회_성공() {
-//        //given
-//        User user = User.builder()
-//                .id(1L)
-//                .email("test@example.com")
-//                .password("password")
-//                .nickname("testuser")
-//                .build();
-//
-//        // UserRepository id찾으면 user를 줌.
-//        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
-//
-//        // Simulation 데이터 준비
-//        Simulation simulation = Simulation.builder()
-//                .id(1L)
-//                .user(user)
-//                .title("테스트 시뮬레이션")
-//                .build();
-//
-//        // SimulationRepository Mocking
-//        given(simulationRepository.findAllByUser(user)).willReturn(List.of(simulation));
-//
-//        // when
-//        List<SimulationSummaryDto> result = simulationService.findAllSimulationsByUserId(user.getId());
-//
-//        // then
-//        assertThat(result).hasSize(1);
-//        assertThat(result.get(0).getTitle()).isEqualTo("테스트 시뮬레이션");
-//        assertThat(result.get(0).getSimulationId()).isEqualTo(simulation.getId());
-//    }
+    @Test
+    @DisplayName("사용자 id로 Simulation 전체 목록 조회 성공")
+    void 사용자_id로_Simulation_전체_목록_조회_성공() {
+        //given
+        User user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("password")
+                .nickname("testuser")
+                .isDeleted(false)
+                .build();
 
-//    현재 단건조회는 수정이 필요
-//    @Test
-//    @DisplayName("사용자가 선택한 simulationId에 해당하는 시뮬레이션 단건 조회 성공")
-//    void findSimulationById() {
-//
-//        User user = User.builder()
-//                .id(1L)
-//                .email("test@example.com")
-//                .password("password")
-//                .nickname("testuser")
-//                .build();
-//
-//        Goal goal1 = Goal.builder().id(1L).build();
-//
-//        //simulationParam(json에 필요한 엔티티)
-//        SimulationParams params = SimulationParams.
-//                builder()
-//                .annualIncomeGrowthRate(0.03)
-//                .annualInvestmentReturnRate(0.05)
-//                .build();
-//
-//        //results생성(results에 필요한 필드)
-//        SimulationResults results = SimulationResults.builder()
-//                .monthlyAssetMap(
-//                        new LinkedHashMap<>(Map.of(
-//                                "2025-01", 1_000_000L,
-//                                "2025-02", 2_000_000L))
-//                ).build();
-//
-//
-//        SimulationGoal simGoal = SimulationGoal.builder()
-//                .goal(goal1)
-//                .build();
-//
-//        // Simulation 데이터 준비
-//        Simulation simulation = Simulation.builder()
-//                .id(1L)
-//                .user(user) // nickname 필요
-//                .title("테스트 시뮬레이션")
-//                .baseDate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()))
-//                .initialAsset(1000000L)
-//                .monthlyIncome(3000000L)
-//                .monthlyExpense(2000000L)
-//                .simulationGoals(List.of(simGoal)) // 적어도 1개는 넣어야 goalIds 에서 NPE 안남
-//                .params(params) // null 넣으면 테스트 시 오류날 수 있음
-//                .results(results) // null 넣으면 테스트 시 오류날 수 있음
-//                .build();
-//
-//        given(simulationRepository.findById(simulation.getId())).willReturn(Optional.of(simulation));
-//
-//        // when
-//        BaseSimulationResponseDto result = simulationService.findSimulationById(user, simulation.getId());
-//
-//        //검증
-//        assertThat(result.getTitle()).isEqualTo("테스트 시뮬레이션");
-//        assertThat(result.getSimulationId()).isEqualTo(simulation.getId());
-//        assertThat(result.getBaseDate()).isEqualTo(simulation.getBaseDate());
-//        assertThat(result.getInitialAsset()).isEqualTo(simulation.getInitialAsset());
-//        assertThat(result.getMonthlyIncome()).isEqualTo(simulation.getMonthlyIncome());
-//        assertThat(result.getMonthlyExpense()).isEqualTo(simulation.getMonthlyExpense());
-//        assertThat(result.getGoalIds()).containsExactly(goal1.getId());
-//        assertThat(result.getParams()).isEqualTo(simulation.getParams());
-//        assertThat(result.getResults()).isEqualTo(simulation.getResults());
-//
-//    }
+        // UserRepository id찾으면 user를 줌.
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
 
+        // Simulation 데이터 준비
+        Simulation simulation = Simulation.builder()
+                .id(1L)
+                .user(user)
+                .title("테스트 시뮬레이션")
+                .build();
 
-//    @Test
-//    @DisplayName("save에서 계산로직이 정상적으로 수행")
-//    void save에서_계산로직이_정상적으로_수행() {
-//        // given
-//        long initialAsset = 2_000_000L; //초기 자산
-//        long monthlyIncome = 2_000_000L; //월 수입
-//        long monthlyExpense = 1_000_000L; //월 지출
-//        Long monthlySaving = null; // 자동 계산 월마다 얼마나 저축 (null이면 monthlyIncome - monthlyExpense되게 해놓음)
-//        double annualInterestRate = 3.0; //연 이자율
-//        int elapsedMonths = 0; //기준일로부터 경과한 개월 수
-//        int totalMonths = 12; //전체 시뮬레이션 기간
-//        LocalDate baseDate = LocalDate.of(2025, 6, 1); //시작 기준일.
-//
-//        List<Goal> goals = List.of(
-//                Goal.builder().id(1L).targetAmount(10_000_000L).build()
-//        );
-//
-//        // CalculateAll 및 Calculator 직접 생성
-//        //빈을 주입하면 스프링컨텍슽트(스프링이 관리하는 객체 저장소) 비용증가 가능성이 있다고 함.
-//        SimulationCalculator calculator = new SimulationCalculator();
-//        CalculateAll calculateAll = new CalculateAll(calculator);
-//
-//        // when 시뮬레이션 계산결과들
-//        SimulationResults results = calculateAll.calculate(
-//                initialAsset,
-//                monthlyIncome,
-//                monthlyExpense,
-//                monthlySaving,
-//                annualInterestRate,
-//                elapsedMonths,
-//                totalMonths,
-//                baseDate,
-//                goals
-//        );
-//
-//        // then
-//        assertThat(results).isNotNull();
-//        //필요금액 확인
-//        assertThat(results.getRequiredAmount()).isEqualTo(8_000_000L);
-//        //목표 달성까지 걸리는 개월 수가 0보다 큼 -> 달성 기간 계산됐는지
-//        assertThat(results.getMonthsToGoal()).isGreaterThan(0);
-//        //현재 달성률 0보다 큼.
-//        assertThat(results.getCurrentAchievementRate()).isGreaterThan(0f);
-//        //월별 자산 변화 리스트 생성됐는지
-//        assertThat(results.getMonthlyAssets()).isNotEmpty();
-//        //달성률 리스트도 잘 생성 됐는지.
-//        assertThat(results.getMonthlyAchievements()).isNotEmpty();
-//    }
+        // SimulationRepository Mocking
+        given(simulationRepository.findAllByUser(user)).willReturn(List.of(simulation));
+
+        // when
+        List<SimulationSummaryDto> result = simulationService.findAllSimulationsByUserId(user.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTitle()).isEqualTo("테스트 시뮬레이션");
+        assertThat(result.get(0).getSimulationId()).isEqualTo(simulation.getId());
+    }
+
+    @Test
+    @DisplayName("save에서 계산로직이 정상적으로 수행")
+    void save에서_계산로직이_정상적으로_수행() {
+        // given
+        //보통 사용자는 수입/지출 항목을 단독으로 관리하며, 목표 기반 계좌와는 별도로 운영할 가능성이 큼. 좀 더  고민해볼 것.
+        long initialAsset = 2_000_000L; //초기 자산
+        long monthlyIncome = 2_000_000L; //월 수입
+        long monthlyExpense = 1_000_000L; //월 지출
+        Long monthlySaving =500000L; // 자동 계산 월마다 얼마나 저축 (null이면 monthlyIncome - monthlyExpense되게 해놔야..)
+        double annualInterestRate = 3.0; //연 이자율
+        int elapsedMonths = 0; //기준일로부터 경과한 개월 수
+        int totalMonths = 12; //전체 시뮬레이션 기간
+        LocalDate baseDate = LocalDate.of(2025, 6, 1); //시작 기준일.
+
+        List<Goal> goals = List.of(
+                Goal.builder().id(1L).targetAmount(10_000_000L).build()
+        );
+
+        // CalculateAll 및 Calculator 직접 생성
+        //빈을 주입하면 스프링컨텍슽트(스프링이 관리하는 객체 저장소) 비용증가 가능성이 있다고 함.
+        SimulationCalculator calculator = new SimulationCalculator();
+        CalculateAll calculateAll = new CalculateAll(calculator);
+
+        // when 시뮬레이션 계산결과들
+        SimulationResults results = calculateAll.calculate(
+                initialAsset,
+                monthlyIncome,
+                monthlyExpense,
+                monthlySaving,
+                annualInterestRate,
+                elapsedMonths,
+                totalMonths,
+                baseDate,
+                goals
+        );
+
+        // then
+        assertThat(results).isNotNull();
+        //필요금액 확인
+        assertThat(results.getRequiredAmount()).isEqualTo(8_000_000L);
+        //목표 달성까지 걸리는 개월 수가 0보다 큼 -> 달성 기간 계산됐는지
+        assertThat(results.getMonthsToGoal()).isGreaterThan(0);
+        //현재 달성률 0보다 큼.
+        assertThat(results.getCurrentAchievementRate()).isGreaterThan(0f);
+        //월별 자산 변화 리스트 생성됐는지
+        assertThat(results.getMonthlyAssets()).isNotEmpty();
+        //달성률 리스트도 잘 생성 됐는지.
+        assertThat(results.getMonthlyAchievements()).isNotEmpty();
+    }
 
 
 //    @Test
@@ -234,256 +190,276 @@ public class SimulationServiceImplTest {
 //
 //    }
 
-//    @Test
-//    @DisplayName("잘못된 goalId가 들어왔을 때 SIMULATION_GOAL_NOT_FOUND 예외 발생")
-//    void saveSimulation은_잘못된id가들어왔을때_CustomException_발생시켜야한다() {
-//        // given
-//        Long invalidGoalId = 999L;
-//
-//        // goalRepository가 빈 리스트를 리턴하도록 설정
-//        when(goalRepository.findAllById(List.of(invalidGoalId)))
-//                .thenReturn(List.of());
-//
-//        LocalDate baseDate = LocalDate.of(2025, 6, 16);
-//
-//        BaseCreateSimulationRequestDto dto = new BaseCreateSimulationRequestDto(
-//                "5년 뒤 내 집 마련",
-//                baseDate,
-//                1_000_000L,
-//                3_000_000L,
-//                2_000_000L,
-//                1_000_000L,
-//                3.0,
-//                0,
-//                60,
-//                List.of(invalidGoalId)
-//        );
-//
-//        User user = User.builder().id(1L).build(); // mock user
-//
-//        // when + then
-//        assertThrows(CustomException.class, () -> {
-//            simulationService.saveSimulation(dto, user.getId(), List.of(invalidGoalId));
-//        });
-//    }
+    @Test
+    @DisplayName("잘못된 goalId가 들어왔을 때 SIMULATION_GOAL_NOT_FOUND 예외 발생")
+    void saveSimulation은_잘못된id가들어왔을때_CustomException_발생시켜야한다() {
+        // given
+        Long invalidGoalId = 999L;
+
+        User user2 = User.builder()
+                .email("test@example.com")
+                .password("password")
+                .nickname("testuser")
+                .isDeleted(false)
+                .build();
+
+        ReflectionTestUtils.setField(user2, "id", 1L);
+
+        given(userRepository.findById(user2.getId()))
+                .willReturn(Optional.of(user2));
+
+        given(goalRepository.findAllWithUserByIdAndUserId(List.of(invalidGoalId), user2.getId()))
+                .willReturn(Collections.emptyList());
+
+        LocalDate baseDate = LocalDate.of(2025, 6, 16);
+
+        BaseCreateSimulationRequestDto dto = new BaseCreateSimulationRequestDto(
+                "5년 뒤 내 집 마련",
+                baseDate,
+                1_000_000L,
+                3_000_000L,
+                2_000_000L,
+                1_000_000L,
+                3.0,
+                0,
+                60,
+                List.of(invalidGoalId)
+        );
+
+        // when + then
+        assertThrows(CustomException.class, () -> {
+            simulationService.saveSimulation(dto, user2.getId(), List.of(invalidGoalId));
+        });
+    }
 
     //batchInsert가 insert가 한 번만 수행되는 것이 맞는지 log로 확인할 수 있음.
     //save에서 batchInsert메서드가 호출이 되는지 확인만 -> 원래 따로 메서드만들어서 테스트하는 것이 좋음.
-//    @Test
-//    void saveSimulation은_batchInsert_호출과_DTO반환을_검증한다() {
-//        //given
-//        User user2 = User.builder()
-//                .email("test@example.com")
-//                .password("password")
-//                .nickname("testuser")
-//                .build();
-//
-//        var savedUser = userRepository.save(user2);
-//
-//
-//        Long goalId = 1L;
-//        Goal mockGoal = Goal.builder()
-//                .id(goalId)
-//                .user(savedUser) // 꼭 넣어야 함 (nullable = false)
-//                .title("테스트 목표")
-//                .category(Category.HOUSING)
-//                .targetAmount(1_000_000L)
-//                .startAt(LocalDateTime.now())
-//                .endAt(LocalDateTime.now().plusMonths(6))
-//                .status(Status.ACTIVE)
-//                .share(Share.PRIVATE)
-//                .build();
-//
-//        // GoalRepository.findAllById()가 goal1 리턴하도록 mock 설정
-//        when(goalRepository.findAllById(List.of(goalId))).thenReturn(List.of(mockGoal));
-//
-//        //simulationParam(json에 필요한 엔티티)
-//        LocalDate baseDate = LocalDate.of(2025, 6, 16);
-//
-//        var dto = new BaseCreateSimulationRequestDto(
-//                "5년 뒤 내 집 마련",
-//                baseDate,
-//                1_000_000L,
-//                3_000_000L,
-//                2_000_000L,
-//                1_000_000L,
-//                3.0,
-//                0,
-//                60,
-//                List.of(mockGoal.getId())
-//        );
-//        SimulationResults mockResults = SimulationResults.builder()
-//                .requiredAmount(8_000_000L)
-//                .monthsToGoal(36)
-//                .currentAchievementRate(10.0f)
-//                .monthlyAchievements(List.of()) // 또는 dummy 데이터
-//                .monthlyAssets(List.of())
-//                .build();
-//
-//        when(calculateAll.calculate(
-//                anyLong(), anyLong(), anyLong(), any(), anyDouble(),
-//                anyInt(), anyInt(), any(LocalDate.class), anyList()
-//        )).thenReturn(mockResults);
-//
-//        // dto에 goalIds에 뭘 넣은거
-//        System.out.println(dto.getGoalIds());
-//
-//        // mockGoal에 어떤 id가 들어갔는지
-//        System.out.println(mockGoal.getId());
-//
-//        //when
-//        //내부 구현에 대한 필드를 몰라야한다
-//        //BaseCreateSimulationRequestDto dto, User user, List<Long> goalIds
-//        CreateSimulationResponseDto result = simulationService.saveSimulation(
-//                dto,
-//                user2.getId(),
-//                List.of(1L) //이거 넘겨줄 때 그냥 goalId가 simulationGoal에 연결되어있는 걸로 가져오느거임.
-//        );
-//
-//        //then
-//        //테스트 중간에 실행되어야 함. 이건 배치 인설트 부분이므로 , 따로 테스트
-//        //verify(simulationGoalJdbcRepository).batchInsertSimulationGoals(anyList());
-//
-//        assertEquals("5년 뒤 내 집 마련", result.getTitle());
-//
-//        assertEquals(1, result.getGoalIds().size());
-//        assertEquals(1L, result.getGoalIds().getFirst());
-//
-//        assertNotNull(result.getGoalIds());
-//
-//    }
+    @Test
+    void saveSimulation은_batchInsert_호출과_DTO반환을_검증한다() {
+        //given
+        User user2 = User.builder()
+                .email("test@example.com")
+                .password("password")
+                .nickname("testuser")
+                .isDeleted(false)
+                .build();
 
-//    @Test
-//    @DisplayName("시뮬레이션이 목표가 연결되어 있어서 softdelete 삭제 불가능")
-//    void 시뮬레이션은_목표가_연결되어있어서_softdelete_삭제가_불가능() {
-//        // given
-//        User user = mock(User.class);
-//        when(user.getId()).thenReturn(1L);
-//
-//        Simulation simulation = simulationRepository.save(Simulation.builder()
-//                .user(user)
-//                .title("test simulation")
-//                .build());
-//
-//
-//        Goal goal = goalRepository.save(Goal.builder()
-//                .title("테스트 목표")
-//                .user(user) // 이거 필요하다면 추가
-//                .build());
-//
-//        SimulationGoal simulationGoal = SimulationGoal.builder()
-//                .simulation(simulation)
-//                .goal(goal)
-//                .isActive(true)
-//                .linkedAt(LocalDateTime.now())
-//                .build();
-//
-//        simulationGoalRepository.save(simulationGoal);
-//
-//        // when & then
-//        assertThrows(CustomException.class, () -> {
-//            simulationService.softDeleteSimulation(user.getId(), simulation.getId());
-//        });
-//    }
+        given(userRepository.findById(user2.getId())).willReturn(Optional.of(user2));
 
-//    @Test
-//    @DisplayName("시뮬레이션이 목표가 연결되어 있어서 softdelete삭제 불가능")
-//    void 시뮬레이션은_목표가_연결되어있어서_softdelete_삭제가_불가e능() {
-//        //given
-//        User user = userRepository.save(User.builder().email("test@example.com").build());
-//        Simulation simulation = Simulation.builder()
-//                .id(1L)
-//                .user(user)
-//                .title("simulation")
-//                .build();
-//
-//        Goal goal = goalRepository.save(Goal.builder() .title("테스트 목표").build());
-//
-//
-//        SimulationGoal simulationGoal = SimulationGoal.builder()
-//                .simulation(simulation)
-//                .goal(goal)
-//                .isActive(true) // 활성 상태
-//                .linkedAt(LocalDateTime.now())
-//                .build();
-//
-//        simulationGoalRepository.save(simulationGoal);
-//
-//        assertThrows(CustomException.class, () -> {
-//            simulationService.softDeleteSimulation(user.getId(), simulation.getId());
-//        });
-//
-//    }
+        Long goalId = 1L;
+        Goal mockGoal = Goal.builder()
+                .id(goalId)
+                .user(user2) // 꼭 넣어야 함 (nullable = false)
+                .title("테스트 목표")
+                .category(Category.HOUSING)
+                .targetAmount(1_000_000L)
+                .startAt(LocalDateTime.now())
+                .endAt(LocalDateTime.now().plusMonths(6))
+                .status(Status.ACTIVE)
+                .share(Share.PRIVATE)
+                .build();
+        System.out.println("mockGoal ID = " + mockGoal.getId());
+        // GoalRepository.findAllById()가 goal1 리턴하도록 mock 설정
+
+        given(goalRepository.findAllWithUserByIdAndUserId(List.of(goalId), user2.getId()))
+                .willReturn(List.of(mockGoal));
+
+        //simulationParam(json에 필요한 엔티티)
+        LocalDate baseDate = LocalDate.of(2025, 6, 16);
+
+        var dto = new BaseCreateSimulationRequestDto(
+                "5년 뒤 내 집 마련",
+                baseDate,
+                1_000_000L,
+                3_000_000L,
+                2_000_000L,
+                1_000_000L,
+                3.0,
+                0,
+                60,
+                List.of(mockGoal.getId())
+        );
+
+        SimulationResults mockResults = SimulationResults.builder()
+                .requiredAmount(8_000_000L)
+                .monthsToGoal(36)
+                .currentAchievementRate(10.0f)
+                .monthlyAchievements(List.of()) // 또는 dummy 데이터
+                .monthlyAssets(List.of())
+                .build();
+
+        given(calculateAll.calculate(
+                anyLong(), anyLong(), anyLong(), any(), anyDouble(),
+                anyInt(), anyInt(), any(LocalDate.class), anyList()
+        )).willReturn(mockResults);
 
 
-//    @Test
-//    @DisplayName("시뮬레이션은 soft delete를 수행")
-//    void 시뮬레이션은_softdelete를_수행() {
-//
-//        // given
-//        User user = User.builder()
-//                .id(1L)
-//                .email("test@example.com")
-//                .build();
-//
-//        Simulation simulation = Simulation.builder()
-//                .id(1L)
-//                .user(user)
-//                .title("simulation")
-//                .build();
-//
-//        given(simulationRepository.save(any(Simulation.class))).willReturn(simulation);
-//
-//        given(simulationRepository.findById(1L)).willReturn(Optional.of(simulation));
-//
-//        // stubbing 활성화 됐는지 확인하는 로직.
-//        given(simulationGoalRepository.findBySimulationIdAndActiveTrue(simulation.getId()))
-//                .willReturn(List.of()); // 활성 목표 없음
-//
-//        // when
-//        DeletedSimulationResponseDto result = simulationService.softDeleteSimulation(user.getId(), simulation.getId());
-//
-//        // then
-//        assertNotNull(result);
-//        assertNotNull(result.getDeletedAt());
-//        assertEquals(simulation.getId(), result.getSimulationId());
-//    }
+        //when
+        //내부 구현에 대한 필드를 몰라야한다
+        //BaseCreateSimulationRequestDto dto, User user, List<Long> goalIds
+        CreateSimulationResponseDto result = simulationService.saveSimulation(
+                dto,
+                user2.getId(),
+                List.of(goalId) //이거 넘겨줄 때 그냥 goalId가 simulationGoal에 연결되어있는 걸로 가져오느거임.
+        );
 
-//    @Test
-//    @DisplayName("시뮬레이션은 완전히 삭제")
-//    void 시뮬레이션_완전히_삭제() {
-//
-//        // given
-//        User user = User.builder()
-//                .id(1L)
-//                .email("test@example.com")
-//                .build();
-//
-//        Simulation simulation = Simulation.builder()
-//                .id(1L)
-//                .user(user)
-//                .title("simulation")
-//                .build();
-//
-//        given(simulationRepository.save(any(Simulation.class))).willReturn(simulation);
-//
-//        given(simulationRepository.findById(1L)).willReturn(Optional.of(simulation));
-//
-//        // stubbing 활성화 됐는지 확인하는 로직.
-//        given(simulationGoalRepository.findBySimulationIdAndActiveTrue(simulation.getId()))
-//                .willReturn(List.of()); // 활성 목표 없음
-//
-//        // when
-//        DeletedSimulationResponseDto result = simulationService.softDeleteSimulation(user.getId(), simulation.getId());
-//
-//        // then
-//        assertNotNull(result);
-//        assertNotNull(result.getDeletedAt());
-//        assertEquals(simulation.getId(), result.getSimulationId());
-//
-//    }
+        //이런 방법으로도 id세팅가능
+        ReflectionTestUtils.setField(result, "simulationId", 1L);
+        //then
+        //테스트 중간에 실행되어야 함. 이건 배치 인설트 부분이므로 , 따로 테스트
+        //verify(simulationGoalJdbcRepository).batchInsertSimulationGoals(anyList());
+        assertEquals("시뮬레이션 ID가 일치", 1L, result.getSimulationId());
+    }
+
+    @Test
+    @DisplayName("시뮬레이션 조회 수행")
+    void 시뮬레이션은_조회를_수행() {
+
+        User user2 = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .isDeleted(false)
+                .build();
+
+        given(userRepository.findById(user2.getId())).willReturn(Optional.of(user2));
+
+        Simulation simulation = Simulation.builder()
+                .id(1L)
+                .user(user2)
+                .title("simulation")
+                .currentAchievementRate(50.0f)
+                .build();
+
+        given(simulationRepository.findById(1L)).willReturn(Optional.of(simulation));
+
+        //유저랑 simulationId랑 같은지 확인하는 것은 예외 검증테스트 로직으로 관리해야 함.
+        BaseSimulationResponseDto simulationResponseDto = simulationService.findSimulationById(user2.getId(), simulation.getId());
+
+        //검증은 값이 잘 조회되는지 나오는지.
+        assertThat(simulationResponseDto).isNotNull();
+        assertThat(simulationResponseDto.getSimulationId()).isEqualTo(simulation.getId());
+        assertThat(simulationResponseDto.getTitle()).isEqualTo("simulation");
+        assertThat(simulationResponseDto.getCurrentAchievementRate()).isEqualTo(50.0f);
+
+    }
+
+    @Test
+    @DisplayName("시뮬레이션 조회는 유저가 일치하지 않으면 예외 수행")
+    void 시뮬레이션_조회시_유저불일치면_예외발생() {
+
+        Long userId = 1L;
+        Long simulationId = 10L;
+
+        User user1 = User.builder().id(userId).isDeleted(false).build();
+        User user2 = User.builder().id(2L).isDeleted(false).build();
+
+        Simulation simulation = Simulation.builder()
+                .id(1L)
+                .user(user2)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user1));
+        given(simulationRepository.findById(simulationId)).willReturn(Optional.of(simulation));
+
+        CustomException ex = assertThrows(CustomException.class, () -> {
+            simulationService.findSimulationById(userId, simulationId);
+        });
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SIMULATION_BAD_REQUEST);
+    }
 
 
+    @DisplayName("시뮬레이션은 soft delete를 수행")
+    @Test
+    void 시뮬레이션은_softdelete를_수행() {
+        // given
+        Long userId = 1L;
+        Long simulationId = 1L;
 
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .isDeleted(false)
+                .build();
 
+        Simulation simulation = Simulation.builder()
+                .id(simulationId)
+                .user(user)
+                .title("simulation")
+                .isDeleted(false)
+                .build();
+
+        given(simulationRepository.findById(simulationId)).willReturn(Optional.of(simulation));
+        //활성 목표 없앰
+        given(simulationGoalRepository.findBySimulationIdAndActiveTrue(simulationId))
+                .willReturn(List.of());
+
+        // when
+        DeletedSimulationResponseDto result = simulationService.softDeleteSimulation(userId, simulationId);
+
+        // then
+        assertNotNull(result);
+        assertNotNull(result.getDeletedAt());
+        assertTrue(simulation.isDeleted());
+    }
+
+    @Test
+    @DisplayName("시뮬레이션이 목표가 연결되어 있어서 softdelete삭제 불가능")
+    void 시뮬레이션은_목표가_연결되어있어서_softdelete_삭제가_불가e능() {
+        //given
+        User user = User.builder().email("test@example.com").build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        Simulation simulation = Simulation.builder()
+                .user(user)
+                .title("simulation")
+                .build();
+        ReflectionTestUtils.setField(simulation, "id", 10L);
+
+        Goal goal = goalRepository.save(Goal.builder().user(user).title("테스트 목표").build());
+
+        SimulationGoal simulationGoal = SimulationGoal.builder()
+                .simulation(simulation)
+                .goal(goal)
+                .active(true)
+                .linkedAt(LocalDateTime.now())
+                .build();
+
+        simulationGoalRepository.save(simulationGoal);
+
+        assertThrows(CustomException.class, () -> {
+            simulationService.softDeleteSimulation(user.getId(), simulation.getId());
+        });
+
+    }
+
+    @Test
+    @DisplayName("시뮬레이션은 완전히 삭제")
+    void 시뮬레이션_완전히_삭제() {
+        // given
+        Long userId = 1L;
+        Long simulationId = 1L;
+
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .isDeleted(false)
+                .build();
+
+        Simulation simulation = Simulation.builder()
+                .id(simulationId)
+                .user(user)
+                .title("simulation")
+                .isDeleted(true) // 이미 soft delete 되어야 함
+                .build();
+
+        given(simulationRepository.findById(simulationId)).willReturn(Optional.of(simulation));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        simulationService.deleteSimulation(userId, simulationId);
+
+        // then
+        verify(simulationRepository).delete(simulation); // delete 호출 여부 검증
+    }
 }

--- a/src/test/java/org/example/lifechart/simulation/SimulationServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/simulation/SimulationServiceImplTest.java
@@ -11,6 +11,7 @@ import org.example.lifechart.domain.simulation.dto.request.BaseCreateSimulationR
 import org.example.lifechart.domain.simulation.dto.response.*;
 import org.example.lifechart.domain.simulation.entity.Simulation;
 import org.example.lifechart.domain.simulation.entity.SimulationGoal;
+import org.example.lifechart.domain.simulation.repository.SimulationGoalJdbcRepository;
 import org.example.lifechart.domain.simulation.repository.SimulationGoalRepository;
 import org.example.lifechart.domain.simulation.repository.SimulationRepository;
 import org.example.lifechart.domain.simulation.service.calculator.CalculateAll;
@@ -60,6 +61,9 @@ public class SimulationServiceImplTest {
 
     @Mock
     private SimulationGoalRepository simulationGoalRepository;
+
+    @Mock
+    private SimulationGoalJdbcRepository simulationGoalJdbcRepository;
 
     @Mock
     private SimulationValidator simulationValidator;
@@ -312,8 +316,8 @@ public class SimulationServiceImplTest {
     }
 
     @Test
-    @DisplayName("시뮬레이션 조회 수행")
-    void 시뮬레이션은_조회를_수행() {
+    @DisplayName("시뮬레이션 단건 조회 수행")
+    void 시뮬레이션은_단건_조회를_수행() {
 
         User user2 = User.builder()
                 .id(1L)


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #
-테스트코드, service로직 수정
## ✨ 변경 사항
- 시뮬레이션 완전  삭제, 소프트딜리트 삭제, 단건조회, 생성, 계산테스트, 전체 목록조회 코드를 추가하였습니다.
- service에서 user검증 로직을 추가하였습니다.

## 📷 Postman 
- 이미지 첨부
---
[시뮬레이션 저장]
-잘못된 id가 들어오면 saveSimulation에서 예외처리
![savesimulation잘못된 id검증](https://github.com/user-attachments/assets/109e0e03-a66f-433f-846f-c934a3205117)
-saveSimulation에서 dto가 잘 반환되는지 확인
![batchinsert와 dto반환](https://github.com/user-attachments/assets/cf01424d-42a3-4c1f-9468-6a781514ecab)

[단건조회]
-단건조회 성공
![조회 수행 성공 단건](https://github.com/user-attachments/assets/1bad80cb-50ab-4381-adc6-4c324cf11c19)
-유저 불일치시 단건조회 실패
![유저 불일치예외 시뮬ㄹ에ㅣ션 조회시](https://github.com/user-attachments/assets/365c69bd-2405-4ec4-a7b7-c1af11c359fb)

[전체조회]
-전체조회 성공
![전체조회 성공](https://github.com/user-attachments/assets/21ad739d-7981-4f18-b9c7-8bed6305fc85)

[계산로직]
![계산로직 정상](https://github.com/user-attachments/assets/40412583-414d-4640-bf2d-eb8fcadff662)

[소프트딜리트]
-정상삭제 성공
![softdelete임](https://github.com/user-attachments/assets/a4776aa8-7844-4a21-89b5-9ed36c527f82)

-목표와 연결되어있으면 삭제 실패
![목표 연결 시뮬에ㅣ 션softdelte불가능](https://github.com/user-attachments/assets/1891ec0a-5a6d-4750-8a6b-19ad57cbb043)

[완전삭제]
-정상삭제 성공
![시뮬레이션 완전 삭제](https://github.com/user-attachments/assets/2add7542-a3de-4641-bcbd-6f1b9978bf7e)

---
## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
