### PR TITLE
[Feat] Goal: 주거 목표 금액 반환 로직 고도화(Local Json > Open API + Redis + 지역별 평균 상승률 반영)

### DIFF
--- a/src/main/java/org/example/lifechart/common/config/RedisConfig.java
+++ b/src/main/java/org/example/lifechart/common/config/RedisConfig.java
@@ -13,7 +13,10 @@ public class RedisConfig {
 	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
 		RedisTemplate<String, String> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
-		template.setDefaultSerializer(new StringRedisSerializer());
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
 		return template;
 	}
 }

--- a/src/main/java/org/example/lifechart/common/config/RedisConfig.java
+++ b/src/main/java/org/example/lifechart/common/config/RedisConfig.java
@@ -1,0 +1,19 @@
+package org.example.lifechart.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setDefaultSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/org/example/lifechart/common/config/RestTemplateConfig.java
+++ b/src/main/java/org/example/lifechart/common/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package org.example.lifechart.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/org/example/lifechart/common/enums/ErrorCode.java
+++ b/src/main/java/org/example/lifechart/common/enums/ErrorCode.java
@@ -88,10 +88,9 @@ public enum ErrorCode implements BaseCode {
 	GOAL_ETC_NOT_FOUND(HttpStatus.NOT_FOUND, "기타 목표가 존재하지 않습니다."),
 	GOAL_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 목표입니다."),
 	GOAL_CATEGORY_DETAIL_MISMATCH(HttpStatus.BAD_REQUEST, "카테고리와 카테고리 입력 필드가 일치하지 않습니다."),
-
-
-
-
+	DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다."),
+	EXTERNAL_API_FAILURE(HttpStatus.BAD_REQUEST, "외부 API 응답 반환에 실패했습니다."),
+	INVALID_REGION_MATCH(HttpStatus.BAD_REQUEST, "지역-세부지역 매칭에 실패했습니다."),
 
 
 

--- a/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
+++ b/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
@@ -83,21 +83,6 @@ public class GoalController {
 	}
 
 	@Operation(
-		summary = "주거 목표 금액 계산 API",
-		description = "주거 목표 입력값을 바탕으로 목표 금액을 계산합니다.",
-		security = @SecurityRequirement(name="bearerAuth")
-	)
-	@PostMapping("/housing/calculate/future")
-	public ResponseEntity<ApiResponse<Long>> calculateHousingTargetAmount(
-		@RequestBody GoalHousingCalculateRequest request,
-		@RequestParam int yearsLater,
-		@AuthenticationPrincipal CustomUserPrincipal principal
-	) {
-		Long targetAmount = goalHousingCalculateService.calculateFutureTargetAmount(request, yearsLater);
-		return ApiResponse.onSuccess(SuccessCode.GOAL_CALCULATE_SUCCESS, targetAmount);
-	}
-
-	@Operation(
 		summary = "목표 생성 API",
 		description = "새로운 목표를 생성합니다.",
 		security = @SecurityRequirement(name="bearerAuth")

--- a/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
+++ b/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
@@ -83,6 +83,21 @@ public class GoalController {
 	}
 
 	@Operation(
+		summary = "주거 목표 금액 계산 API",
+		description = "주거 목표 입력값을 바탕으로 목표 금액을 계산합니다.",
+		security = @SecurityRequirement(name="bearerAuth")
+	)
+	@PostMapping("/housing/calculate/future")
+	public ResponseEntity<ApiResponse<Long>> calculateHousingTargetAmount(
+		@RequestBody GoalHousingCalculateRequest request,
+		@RequestParam int yearsLater,
+		@AuthenticationPrincipal CustomUserPrincipal principal
+	) {
+		Long targetAmount = goalHousingCalculateService.calculateFutureTargetAmount(request, yearsLater);
+		return ApiResponse.onSuccess(SuccessCode.GOAL_CALCULATE_SUCCESS, targetAmount);
+	}
+
+	@Operation(
 		summary = "목표 생성 API",
 		description = "새로운 목표를 생성합니다.",
 		security = @SecurityRequirement(name="bearerAuth")

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalCreateRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalCreateRequest.java
@@ -74,19 +74,6 @@ public class GoalCreateRequest implements HaSGoalPeriod {
 	@NotEmpty(message = "태그는 필수 입력입니다.")
 	private List<String> tags;
 
-	public Goal toEntity(User user) { // GoalCreateDto를 Goal entity로 변환하는 메서드. 서비스 레이어에서 활용 예정
-		return Goal.builder()
-			.user(user)
-			.title(title)
-			.category(category)
-			.startAt(startAt != null ? startAt : LocalDateTime.now())
-			.endAt(endAt)
-			.targetAmount(targetAmount)
-			.status(Status.ACTIVE)
-			.share(share != null ? share : Share.PRIVATE)
-			.tags(tags)
-			.build();
-	}
 
 	@Override
 	public LocalDateTime getStartAt() {

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalCreateRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalCreateRequest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -69,6 +70,10 @@ public class GoalCreateRequest implements HaSGoalPeriod {
 	@NotNull(message = "공유 설정은 필수 입력입니다.")
 	private Share share; // nullable
 
+	@Schema(description = "태그", example = "[주거, 강남]")
+	@NotEmpty(message = "태그는 필수 입력입니다.")
+	private List<String> tags;
+
 	public Goal toEntity(User user) { // GoalCreateDto를 Goal entity로 변환하는 메서드. 서비스 레이어에서 활용 예정
 		return Goal.builder()
 			.user(user)
@@ -79,6 +84,7 @@ public class GoalCreateRequest implements HaSGoalPeriod {
 			.targetAmount(targetAmount)
 			.status(Status.ACTIVE)
 			.share(share != null ? share : Share.PRIVATE)
+			.tags(tags)
 			.build();
 	}
 

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalEtcRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalEtcRequest.java
@@ -27,11 +27,4 @@ public class GoalEtcRequest implements GoalDetailRequest {
 	@NotNull(message = "필요 금액은 필수 입력입니다.")
 	private Long expectedPrice;
 
-	public GoalEtc toEntity(Goal goal) {
-		return GoalEtc.builder()
-			.goal(goal)
-			.theme(theme)
-			.expectedPrice(expectedPrice)
-			.build();
-	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalHousingCalculateRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalHousingCalculateRequest.java
@@ -29,7 +29,7 @@ public class GoalHousingCalculateRequest implements HaSGoalPeriod {
 	@NotNull(message = "시작일은 필수 입력값입니다.")
 	private LocalDateTime startAt;
 
-	@Schema(description = "종료일", example = "2025-07-31T00:00:00")
+	@Schema(description = "종료일", example = "2030-07-31T00:00:00 - 미래 예측을 원할 경우 1년 이상 기간 설정 필요")
 	@NotNull(message = "종료일은 필수 입력값입니다.")
 	private LocalDateTime endAt;
 

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalHousingRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalHousingRequest.java
@@ -41,13 +41,4 @@ public class GoalHousingRequest implements GoalDetailRequest {
 	@JsonProperty("housingType")
 	private HousingType housingType;
 
-	public GoalHousing toEntity(Goal goal) {
-		return GoalHousing.builder()
-			.goal(goal)
-			.region(region)
-			.subregion(subregion)
-			.area(area)
-			.housingType(housingType)
-			.build();
-	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalRetirementRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalRetirementRequest.java
@@ -40,14 +40,4 @@ public class GoalRetirementRequest implements GoalDetailRequest {
 	@NotNull(message = "기대 수명은 필수 입력입니다.")
 	private Long expectedLifespan; // endAt보다 크거나 같음을 검증하는 로직 필요. 어디에서 할지는 고민 필요
 
-	public GoalRetirement toEntity(Goal goal, int birthYear) {
-		LocalDate expectedDeathDate = GoalDateHelper.toExpectedDeathDate(expectedLifespan, birthYear);
-
-		return GoalRetirement.builder()
-			.goal(goal)
-			.monthlyExpense(monthlyExpense)
-			.retirementType(retirementType)
-			.expectedDeathDate(expectedDeathDate)
-			.build();
-	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalUpdateRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalUpdateRequest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,4 +52,8 @@ public class GoalUpdateRequest {
 	@JsonProperty("share")
 	@NotNull(message = "공유 설정은 필수 입력입니다.")
 	private Share share; // nullable
+
+	@Schema(description = "태그", example = "[주거, 강남]")
+	@NotEmpty(message = "태그는 필수 입력입니다.")
+	private List<String> tags;
 }

--- a/src/main/java/org/example/lifechart/domain/goal/dto/response/ApartmentPriceDto.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/response/ApartmentPriceDto.java
@@ -1,0 +1,17 @@
+package org.example.lifechart.domain.goal.dto.response;
+
+import java.io.Serializable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApartmentPriceDto implements Serializable {
+
+	private String region;
+	private String subregion;
+	private String period; // 기준연월
+	private double price; // 가격
+	private String unit; // 가격 단위
+}

--- a/src/main/java/org/example/lifechart/domain/goal/dto/response/GoalInfoResponse.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/response/GoalInfoResponse.java
@@ -1,5 +1,7 @@
 package org.example.lifechart.domain.goal.dto.response;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,6 +20,7 @@ public class GoalInfoResponse {
     private Status status;
     private Share share;
     private GoalDetailInfoResponse detail;
+    private List<String> tags;
 
     public static GoalInfoResponse from(Goal goal, GoalDetailInfoResponse detail) {
         return GoalInfoResponse.builder()
@@ -27,6 +30,7 @@ public class GoalInfoResponse {
             .status(goal.getStatus())
             .share(goal.getShare())
             .detail(detail)
+            .tags(goal.getTags())
             .build();
 
     }

--- a/src/main/java/org/example/lifechart/domain/goal/dto/response/GoalSummaryResponse.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/response/GoalSummaryResponse.java
@@ -1,7 +1,7 @@
 package org.example.lifechart.domain.goal.dto.response;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.example.lifechart.domain.goal.entity.Goal;
 import org.example.lifechart.domain.goal.enums.Status;
@@ -18,6 +18,7 @@ public class GoalSummaryResponse {
 	private LocalDateTime startAt;
 	private LocalDateTime endAt;
 	private Status status;
+	private List<String> tags;
 
 	public static GoalSummaryResponse from(Goal goal) {
 		return GoalSummaryResponse.builder()
@@ -26,6 +27,7 @@ public class GoalSummaryResponse {
 			.startAt(goal.getStartAt())
 			.endAt(goal.getEndAt())
 			.status(goal.getStatus())
+			.tags(goal.getTags())
 			.build();
 	}
 

--- a/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
@@ -1,6 +1,8 @@
 package org.example.lifechart.domain.goal.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.example.lifechart.common.entity.BaseEntity;
 import org.example.lifechart.domain.goal.dto.request.GoalUpdateRequest;
@@ -9,7 +11,9 @@ import org.example.lifechart.domain.goal.enums.Share;
 import org.example.lifechart.domain.goal.enums.Status;
 import org.example.lifechart.domain.user.entity.User;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -66,6 +70,17 @@ public class Goal extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private Share share;
 
+	@Column(nullable = false)
+	private int commentCount = 0;
+
+	@Column(nullable = false)
+	private int likeCount = 0;
+
+	@ElementCollection(fetch = FetchType.LAZY)
+	@CollectionTable(name = "post_tags", joinColumns = @JoinColumn(name = "post_id"))
+	@Column(name = "tag")
+	private List<String> tags = new ArrayList<>();
+
 	public void delete() {
 		this.status = Status.DELETED;
 	}
@@ -76,5 +91,6 @@ public class Goal extends BaseEntity {
 		startAt = request.getStartAt();
 		endAt = request.getEndAt();
 		share = request.getShare();
+		tags =  request.getTags();
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.example.lifechart.common.entity.BaseEntity;
+import org.example.lifechart.domain.goal.dto.request.GoalCreateRequest;
 import org.example.lifechart.domain.goal.dto.request.GoalUpdateRequest;
 import org.example.lifechart.domain.goal.enums.Category;
 import org.example.lifechart.domain.goal.enums.Share;
@@ -83,6 +84,19 @@ public class Goal extends BaseEntity {
 
 	public void delete() {
 		this.status = Status.DELETED;
+	}
+
+	public static Goal from(GoalCreateRequest request, User user) {
+		return Goal.builder()
+			.user(user)
+			.title(request.getTitle())
+			.category(request.getCategory())
+			.targetAmount(request.getTargetAmount())
+			.startAt(request.getStartAt())
+			.endAt(request.getEndAt())
+			.share(request.getShare())
+			.tags(request.getTags())
+			.build();
 	}
 
 	public void update(GoalUpdateRequest request) {

--- a/src/main/java/org/example/lifechart/domain/goal/entity/GoalEtc.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/GoalEtc.java
@@ -1,6 +1,7 @@
 package org.example.lifechart.domain.goal.entity;
 
 import org.example.lifechart.common.entity.BaseEntity;
+import org.example.lifechart.domain.goal.dto.request.GoalCreateRequest;
 import org.example.lifechart.domain.goal.dto.request.GoalEtcRequest;
 
 import jakarta.persistence.Column;
@@ -37,6 +38,14 @@ public class GoalEtc extends BaseEntity {
 
 	@Column(nullable = false)
 	private Long expectedPrice;
+
+	public static GoalEtc from(Goal goal, GoalEtcRequest request) {
+		return GoalEtc.builder()
+			.goal(goal)
+			.theme(request.getTheme())
+			.expectedPrice(request.getExpectedPrice())
+			.build();
+	}
 
 	public void update(GoalEtcRequest request) {
 		this.theme = request.getTheme();

--- a/src/main/java/org/example/lifechart/domain/goal/entity/GoalHousing.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/GoalHousing.java
@@ -47,6 +47,16 @@ public class GoalHousing extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private HousingType housingType;
 
+	public static GoalHousing from(Goal goal, GoalHousingRequest request) {
+		return GoalHousing.builder()
+			.goal(goal)
+			.region(request.getRegion())
+			.subregion(request.getSubregion())
+			.area(request.getArea())
+			.housingType(request.getHousingType())
+			.build();
+	}
+
 	public void update(GoalHousingRequest request) {
 		this.region = request.getRegion();
 		this.subregion = request.getSubregion();

--- a/src/main/java/org/example/lifechart/domain/goal/entity/GoalRetirement.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/GoalRetirement.java
@@ -48,6 +48,18 @@ public class GoalRetirement extends BaseEntity {
 	@Column(nullable = false)
 	private Long monthlyExpense;
 
+	public static GoalRetirement from(Goal goal, GoalRetirementRequest request, int birthYear) {
+
+		LocalDate expectedDeathDate = GoalDateHelper.toExpectedDeathDate(request.getExpectedLifespan(), birthYear);
+
+		return GoalRetirement.builder()
+			.goal(goal)
+			.retirementType(request.getRetirementType())
+			.expectedDeathDate(expectedDeathDate)
+			.monthlyExpense(request.getMonthlyExpense())
+			.build();
+	}
+
 	public void update(GoalRetirementRequest request, int birthYear) {
 		this.retirementType = request.getRetirementType();
 		this.expectedDeathDate = GoalDateHelper.toExpectedDeathDate(request.getExpectedLifespan(), birthYear);

--- a/src/main/java/org/example/lifechart/domain/goal/enums/RegionCode.java
+++ b/src/main/java/org/example/lifechart/domain/goal/enums/RegionCode.java
@@ -1,0 +1,80 @@
+package org.example.lifechart.domain.goal.enums;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionCode {
+	// format: code, subregionName, regionName
+
+	KOREA("000", "전국", "전국"),
+	CAPITAL("010", "수도권", "수도권"),
+	LOCAL("020", "지방", "지방"),
+
+	// 서울 및 권역
+	SEOUL("030", "서울", "서울"),
+	SEOUL_CENTER("0301", "도심권", "서울"),
+	SEOUL_NE("0302", "동북권", "서울"),
+	SEOUL_SE("0303", "동남권", "서울"),
+	SEOUL_NW("0304", "서북권", "서울"),
+	SEOUL_SW("0305", "서남권", "서울"),
+
+	// 광역시
+	BUSAN("040", "부산", "부산"),
+	DAEGU("050", "대구", "대구"),
+	INCHEON("060", "인천", "인천"),
+	GWANGJU("070", "광주", "광주"),
+	DAEJEON("080", "대전", "대전"),
+	ULSAN("090", "울산", "울산"),
+	SEJONG("091", "세종", "세종"),
+
+	// 도
+	GYEONGGI("100", "경기", "경기"),
+	GANGWON("110", "강원", "강원"),
+	CHUNGBUK("120", "충북", "충북"),
+	CHUNGNAM("130", "충남", "충남"),
+	JEONBUK("140", "전북", "전북"),
+	JEONNAM("150", "전남", "전남"),
+	GYEONGBUK("160", "경북", "경북"),
+	GYEONGNAM("170", "경남", "경남"),
+	JEJU("180", "제주", "제주"),
+
+	UNKNOWN("999", "기타", "기타");
+
+	private final String code;
+	private final String subregion;
+	private final String region;
+
+	private static final Map<String, RegionCode> codeMap = new HashMap<>();
+
+	static {
+		for (RegionCode rc : values()) {
+			codeMap.put(rc.code, rc);
+		}
+	}
+
+	public static RegionCode fromCode(String code) {
+		return codeMap.getOrDefault(code, UNKNOWN);
+	}
+
+	public static String getRegionName(String code) {
+		return fromCode(code).getRegion();
+	}
+
+	public static String getSubregionName(String code) {
+		return fromCode(code).getSubregion();
+	}
+
+	public static List<RegionCode> getValidCodes() {
+		return Arrays.stream(values())
+			.filter(code -> !code.equals(UNKNOWN))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
@@ -1,0 +1,10 @@
+package org.example.lifechart.domain.goal.repository;
+
+import java.util.Optional;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+
+public interface ApartmentPriceCacheRepository {
+	Optional<ApartmentPriceDto> find(String region, String subregion);
+	void save(ApartmentPriceDto dto);
+}

--- a/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
@@ -2,9 +2,11 @@ package org.example.lifechart.domain.goal.repository;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
 
 public interface ApartmentPriceCacheRepository {
 	Optional<ApartmentPriceDto> find(String region, String subregion);
+	Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion, int years);
 	void save(ApartmentPriceDto dto);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
@@ -1,17 +1,30 @@
 package org.example.lifechart.domain.goal.repository;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.example.lifechart.common.enums.ErrorCode;
+import org.example.lifechart.common.exception.CustomException;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RedisApartmentPriceRepository implements ApartmentPriceCacheRepository {
@@ -19,15 +32,15 @@ public class RedisApartmentPriceRepository implements ApartmentPriceCacheReposit
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper;
 
-	private static final Duration TTL = Duration.ofDays(1); // 1일 캐시 유지
+	private static final Duration TTL = Duration.ofDays(30); // 1일 캐시 유지
 
-	private String generateKey(String region, String subregion) {
-		return "apt-price::" + region + "::" + subregion;
+	private String generateKey(String region, String subregion, String period) {
+		return "apt-price::" + region + "::" + subregion + "::" + period;
 	}
 
 	@Override
 	public Optional<ApartmentPriceDto> find(String region, String subregion) {
-		String key = generateKey(region, subregion);
+		String key = generateKey(region, subregion, null);
 		String value = redisTemplate.opsForValue().get(key);
 
 		if (value == null)
@@ -42,13 +55,83 @@ public class RedisApartmentPriceRepository implements ApartmentPriceCacheReposit
 	}
 
 	@Override
+	public Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion, int years) {
+
+		// 1. 데이터 중 가장 최신 period 구하기
+		String latestPeriod = findLatestPeriod(region, subregion); // 예: "202504"
+		YearMonth end = YearMonth.parse(latestPeriod, DateTimeFormatter.ofPattern("yyyyMM"));
+		YearMonth start = end.minusYears(years);
+
+		String startKey = generateKey(region, subregion, start.format(DateTimeFormatter.ofPattern("yyyyMM")));
+		String endKey = generateKey(region, subregion, latestPeriod);
+
+		ApartmentPriceDto startDto = null;
+		ApartmentPriceDto endDto = null;
+
+		try {
+			String startJson = redisTemplate.opsForValue().get(startKey);
+			if (startJson != null) {
+				startDto = objectMapper.readValue(startJson, ApartmentPriceDto.class);
+			}
+
+			String endJson = redisTemplate.opsForValue().get(endKey);
+			if (endJson != null) {
+				endDto = objectMapper.readValue(endJson, ApartmentPriceDto.class);
+			}
+
+			if (startDto != null && endDto != null) {
+				return Optional.of(Pair.of(startDto, endDto));
+			}
+		} catch (Exception e) {
+			log.warn("Redis price fetch failed: {}", e.getMessage());
+		}
+
+		return Optional.empty();
+	}
+
+	@Override
 	public void save(ApartmentPriceDto dto) {
-		String key = generateKey(dto.getRegion(), dto.getSubregion());
+		String key = generateKey(dto.getRegion(), dto.getSubregion(), dto.getPeriod());
 		try {
 			String json = objectMapper.writeValueAsString(dto);
 			redisTemplate.opsForValue().set(key, json, TTL);
 		} catch (JsonProcessingException e) {
 			// Log error
 		}
+	}
+
+	private String findLatestPeriod(String region, String subregion) {
+
+		String prefix = "apt-price::" + region + "::" + subregion + "::";
+		ScanOptions options = ScanOptions.scanOptions()
+			.match(prefix + "*")
+			.count(100)
+			.build();
+
+		Set<String> periods = new HashSet<>();
+
+		try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+			.getConnection()
+			.scan(options)) {
+
+			while (cursor.hasNext()) {
+				String key = new String(cursor.next(), StandardCharsets.UTF_8); // byte[] -> String
+				String[] parts = key.split("::");
+				if (parts.length == 4) {
+					periods.add(parts[3]);
+				}
+			}
+
+		} catch (Exception e) {
+			log.error("Redis SCAN 실패 : {}", e.getMessage(), e);
+			throw new CustomException(ErrorCode.EXTERNAL_API_FAILURE);
+		}
+
+		log.debug("Latest periods found for {}-{}: {}", region, subregion, periods);
+
+		// 최신 period 반환
+		return periods.stream()
+			.max(Comparator.naturalOrder()) // 문자열 정렬
+			.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
@@ -1,0 +1,54 @@
+package org.example.lifechart.domain.goal.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisApartmentPriceRepository implements ApartmentPriceCacheRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private static final Duration TTL = Duration.ofDays(1); // 1일 캐시 유지
+
+	private String generateKey(String region, String subregion) {
+		return "apt-price::" + region + "::" + subregion;
+	}
+
+	@Override
+	public Optional<ApartmentPriceDto> find(String region, String subregion) {
+		String key = generateKey(region, subregion);
+		String value = redisTemplate.opsForValue().get(key);
+
+		if (value == null)
+			return Optional.empty();
+
+		try {
+			ApartmentPriceDto dto = objectMapper.readValue(value, ApartmentPriceDto.class);
+			return Optional.of(dto);
+		} catch (JsonProcessingException e) {
+			return Optional.empty(); // or Log error
+		}
+	}
+
+	@Override
+	public void save(ApartmentPriceDto dto) {
+		String key = generateKey(dto.getRegion(), dto.getSubregion());
+		try {
+			String json = objectMapper.writeValueAsString(dto);
+			redisTemplate.opsForValue().set(key, json, TTL);
+		} catch (JsonProcessingException e) {
+			// Log error
+		}
+	}
+}

--- a/src/main/java/org/example/lifechart/domain/goal/scheduler/ApartmentPriceSyncScheduler.java
+++ b/src/main/java/org/example/lifechart/domain/goal/scheduler/ApartmentPriceSyncScheduler.java
@@ -1,0 +1,41 @@
+package org.example.lifechart.domain.goal.scheduler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.example.lifechart.domain.goal.enums.RegionCode;
+import org.example.lifechart.domain.goal.repository.ApartmentPriceCacheRepository;
+import org.example.lifechart.domain.goal.service.OpenApiApartmentPriceService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApartmentPriceSyncScheduler {
+
+	private final OpenApiApartmentPriceService apiService;
+	private final ApartmentPriceCacheRepository redisRepository;
+
+	@Scheduled(cron = "0 0 0 1 * *")
+	public void sync() {
+		for (RegionCode code : RegionCode.getValidCodes()) {
+			String region = code.getRegion();
+			String subregion = code.getSubregion();
+
+			try {
+				ApartmentPriceDto dto = apiService.fetchLatest(region, subregion);
+				if (dto != null) {
+					redisRepository.save(dto);
+				}
+			} catch (Exception e) {
+				log.warn("Failed to fetch/save apartment price for region: {}, subregion: {}", region, subregion, e);
+			}
+		}
+	}
+}

--- a/src/main/java/org/example/lifechart/domain/goal/service/ApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/ApartmentPriceService.java
@@ -4,4 +4,5 @@ import java.io.IOException;
 
 public interface ApartmentPriceService {
 	Long getAveragePrice(String region, String subregion, Long area);
+	Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
@@ -13,7 +13,7 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 	private final ApartmentPriceCacheRepository redisRepository;
 	private final OpenApiApartmentPriceService openApiService;
 
-	@Override
+	@Override // 현재 시점의 가격 계싼
 	public Long getAveragePrice(String region, String subregion, Long area) {
 		ApartmentPriceDto dto = redisRepository.find(region, subregion)
 			.orElseGet(() -> {
@@ -24,7 +24,7 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 		return Math.round(dto.getPrice() * area * 10_000L); // price 단위가 만원으로, 원 단위 환산
 	}
 
-	@Override // 추후 목표 설정의 '종료일'과 결합해 활용할 예정
+	@Override // 미래 시점의 가격 계싼
 	public Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater) {
 		Long current = getAveragePrice(region, subregion, area);
 		double rate = openApiService.getAnnualGrowthRate(subregion);

--- a/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
@@ -1,5 +1,8 @@
 package org.example.lifechart.domain.goal.service;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
 import org.example.lifechart.domain.goal.repository.ApartmentPriceCacheRepository;
 import org.springframework.stereotype.Service;
@@ -27,8 +30,22 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 	@Override // 미래 시점의 가격 계싼
 	public Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater) {
 		Long current = getAveragePrice(region, subregion, area);
-		double rate = openApiService.getAnnualGrowthRate(subregion);
+		double rate = calculateAnnualGrowthRate(region, subregion, 10);
 		return Math.round(current * Math.pow(1+rate, yearsLater));
+	}
+
+	private double calculateAnnualGrowthRate(String region, String subregion, int years) {
+		// 1. 과거 N년 데이터 중 가장 최신/오래된 데이터 가져오기
+		Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> pairOpt = redisRepository.findStartAndEnd(region, subregion, years);
+
+		if (pairOpt.isEmpty()) return 0.03; // fallback
+
+		// 2. 가장 오래된 값과 최신값 비교
+		ApartmentPriceDto start = pairOpt.get().getLeft();
+		ApartmentPriceDto end = pairOpt.get().getRight();
+
+		// 3. CAGR (복리 성장률) 계산
+		return Math.pow(end.getPrice() / start.getPrice(), 1.0/ years) - 1 ;
 	}
 
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
@@ -1,0 +1,34 @@
+package org.example.lifechart.domain.goal.service;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.example.lifechart.domain.goal.repository.ApartmentPriceCacheRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CachedApartmentPriceService implements ApartmentPriceService {
+
+	private final ApartmentPriceCacheRepository redisRepository;
+	private final OpenApiApartmentPriceService openApiService;
+
+	@Override
+	public Long getAveragePrice(String region, String subregion, Long area) {
+		ApartmentPriceDto dto = redisRepository.find(region, subregion)
+			.orElseGet(() -> {
+				ApartmentPriceDto fetched = openApiService.fetchLatest(region, subregion);
+				redisRepository.save(fetched);
+				return fetched;
+			});
+		return Math.round(dto.getPrice() * area * 10_000L); // price 단위가 만원으로, 원 단위 환산
+	}
+
+	@Override // 추후 목표 설정의 '종료일'과 결합해 활용할 예정
+	public Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater) {
+		Long current = getAveragePrice(region, subregion, area);
+		double rate = openApiService.getAnnualGrowthRate(subregion);
+		return Math.round(current * Math.pow(1+rate, yearsLater));
+	}
+
+}

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateService.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GoalHousingApartmentCalculateService implements GoalHousingCalculateService {
 
-	private final JsonApartmentPriceService apartmentPriceService;
+	//private final JsonApartmentPriceService apartmentPriceService;
+	private final CachedApartmentPriceService apartmentPriceService;
 
 	@Override
 	public boolean supports(HousingType type) {
@@ -23,5 +24,15 @@ public class GoalHousingApartmentCalculateService implements GoalHousingCalculat
 		String subregion = request.getSubregion();
 		Long area = request.getArea();
 		return apartmentPriceService.getAveragePrice(region, subregion, area);
-	};
+	}
+
+	@Override
+	public Long calculateFutureTargetAmount(GoalHousingCalculateRequest request, int yearsLater) {
+		String region = request.getRegion();
+		String subregion = request.getSubregion();
+		Long area = request.getArea();
+		return apartmentPriceService.getFuturePredictedPrice(region, subregion, area, yearsLater);
+	}
+
+	;
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateService.java
@@ -1,5 +1,8 @@
 package org.example.lifechart.domain.goal.service;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import org.example.lifechart.domain.goal.dto.request.GoalHousingCalculateRequest;
 import org.example.lifechart.domain.goal.enums.HousingType;
 import org.springframework.stereotype.Service;
@@ -10,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GoalHousingApartmentCalculateService implements GoalHousingCalculateService {
 
-	//private final JsonApartmentPriceService apartmentPriceService;
 	private final CachedApartmentPriceService apartmentPriceService;
 
 	@Override
@@ -20,19 +22,22 @@ public class GoalHousingApartmentCalculateService implements GoalHousingCalculat
 
 	@Override
 	public Long calculateTargetAmount(GoalHousingCalculateRequest request) {
+
 		String region = request.getRegion();
 		String subregion = request.getSubregion();
 		Long area = request.getArea();
-		return apartmentPriceService.getAveragePrice(region, subregion, area);
+		LocalDateTime startAt = request.getStartAt();
+		LocalDateTime endAt = request.getEndAt();
+		int yearsLater = (int) ChronoUnit.YEARS.between(startAt, endAt);
+
+		if (isFuturePeriod(startAt, endAt)) {
+			return apartmentPriceService.getFuturePredictedPrice(region, subregion, area, yearsLater);
+		} else {
+			return apartmentPriceService.getAveragePrice(region, subregion, area);
+		}
 	}
 
-	@Override
-	public Long calculateFutureTargetAmount(GoalHousingCalculateRequest request, int yearsLater) {
-		String region = request.getRegion();
-		String subregion = request.getSubregion();
-		Long area = request.getArea();
-		return apartmentPriceService.getFuturePredictedPrice(region, subregion, area, yearsLater);
+	private boolean isFuturePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+		return endAt.isAfter(startAt.plusMonths(12)); // 12개월 이상이면 미래로 간주
 	}
-
-	;
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingCalculateService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingCalculateService.java
@@ -6,5 +6,4 @@ import org.example.lifechart.domain.goal.enums.HousingType;
 public interface GoalHousingCalculateService {
 	boolean supports(HousingType type);
 	Long calculateTargetAmount(GoalHousingCalculateRequest request);
-	Long calculateFutureTargetAmount(GoalHousingCalculateRequest request, int yearsLater);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingCalculateService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalHousingCalculateService.java
@@ -6,4 +6,5 @@ import org.example.lifechart.domain.goal.enums.HousingType;
 public interface GoalHousingCalculateService {
 	boolean supports(HousingType type);
 	Long calculateTargetAmount(GoalHousingCalculateRequest request);
+	Long calculateFutureTargetAmount(GoalHousingCalculateRequest request, int yearsLater);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
@@ -57,7 +57,7 @@ public class GoalServiceImpl implements GoalService {
 		validateCategoryAndDetail(requestDto.getCategory(), detail);
 
 		// Goal Entity 반환
-		Goal newGoal = requestDto.toEntity(user);
+		Goal newGoal = Goal.from(requestDto, user);
 		Goal savedGoal = goalRepository.save(newGoal);
 		saveGoalDetail(detail, savedGoal, user);
 
@@ -142,13 +142,13 @@ public class GoalServiceImpl implements GoalService {
 
 	private void saveGoalDetail(GoalDetailRequest detail, Goal savedGoal, User user) {
 		if (detail instanceof GoalRetirementRequest retirementDetail) {
-			GoalRetirement goalRetirement = retirementDetail.toEntity(savedGoal, user.getBirthDate().getYear());
+			GoalRetirement goalRetirement = GoalRetirement.from(savedGoal, retirementDetail, user.getBirthDate().getYear());
 			goalRetirementRepository.save(goalRetirement);
 		} else if (detail instanceof GoalHousingRequest housingDetail) {
-			GoalHousing goalHousing = housingDetail.toEntity(savedGoal);
+			GoalHousing goalHousing = GoalHousing.from(savedGoal, housingDetail);
 			goalHousingRepository.save(goalHousing);
 		} else if (detail instanceof GoalEtcRequest etcDetail) {
-			GoalEtc goalEtc = etcDetail.toEntity(savedGoal);
+			GoalEtc goalEtc = GoalEtc.from(savedGoal, etcDetail);
 			goalEtcRepository.save(goalEtc);
 		} else {
 			throw new CustomException(ErrorCode.GOAL_INVALID_CATEGORY);

--- a/src/main/java/org/example/lifechart/domain/goal/service/JsonApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/JsonApartmentPriceService.java
@@ -37,6 +37,11 @@ public class JsonApartmentPriceService implements ApartmentPriceService {
 	public Long getAveragePrice(String region, String subregion, Long area) {
 		Double pricePerMeter = apartmentPriceMap.getOrDefault(region, Map.of())
 			.getOrDefault(subregion, 0.0);
-		return Math.round(pricePerMeter * area * 10_000_000L); // 단위가 천만원으로, 원 단위 환산
+		return Math.round(pricePerMeter * area * 10_000L); // 평당 가격 단위가 만원으로, 원 단위 환산
+	}
+
+	@Override
+	public Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater) {
+		return null;
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
@@ -40,7 +40,7 @@ public class OpenApiApartmentPriceService {
 
 
 	public ApartmentPriceDto fetchLatest(String region, String subregion) {
-		String API_URL = buildUrl(60); // 최근 60개월
+		String API_URL = buildUrl(120); // 최근 60개월
 		try {
 			String response = restTemplate.getForObject(API_URL, String.class);
 			List<Map<String, Object>> dataList = objectMapper.readValue(response, new TypeReference<>() {});
@@ -83,10 +83,5 @@ public class OpenApiApartmentPriceService {
 			DEFAULT_PARAMS +
 			"&newEstPrdCnt=" + months +
 			"&apiKey=" + apiKey;
-	}
-
-	public double getAnnualGrowthRate(String subregion) {
-		// 추후 구현
-		return 0.04; // 예시: 4% 상승률
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
@@ -1,0 +1,92 @@
+package org.example.lifechart.domain.goal.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.example.lifechart.common.enums.ErrorCode;
+import org.example.lifechart.common.exception.CustomException;
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.example.lifechart.domain.goal.enums.RegionCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OpenApiApartmentPriceService {
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Value("${openapi.kosis.key}")
+	private String apiKey;
+
+	private static final String BASE_URL = "https://kosis.kr/openapi/Param/statisticsParameterData.do";
+	private static final String DEFAULT_PARAMS =
+		"?method=getList" +
+			"&itmId=T001+" +
+			"&objL1=ALL" +
+			"&objL2=&objL3=&objL4=&objL5=&objL6=&objL7=&objL8=" +
+			"&format=json&jsonVD=Y&prdSe=M" +
+			"&outputFields=OBJ_ID+OBJ_NM+NM+ITM_ID+ITM_NM+UNIT_NM+PRD_SE+PRD_DE+LST_CHN_DE+" +
+			"&orgId=408&tblId=DT_KAB_11672_S15";
+
+
+	public ApartmentPriceDto fetchLatest(String region, String subregion) {
+		String API_URL = buildUrl(60); // 최근 60개월
+		try {
+			String response = restTemplate.getForObject(API_URL, String.class);
+			List<Map<String, Object>> dataList = objectMapper.readValue(response, new TypeReference<>() {});
+
+			// 최신 데이터 추출
+			Optional<Map<String, Object>> latestEntry = dataList.stream()
+				.filter(item -> subregion.equals(item.get("C1_NM")))
+				.max(Comparator.comparing(item -> (String) item.get("PRD_DE")));
+
+			if (latestEntry.isEmpty()) {
+				throw new CustomException(ErrorCode.DATA_NOT_FOUND);
+			}
+
+			Map<String, Object> entry = latestEntry.get();
+
+			// 지역 코드 -> RegionCode enum 매핑
+			String code = (String) entry.get("C1"); //
+			RegionCode regionCode = RegionCode.fromCode(code);
+
+			if (!regionCode.getRegion().equals(region) || !regionCode.getSubregion().equals(subregion)) {
+				throw new CustomException(ErrorCode.INVALID_REGION_MATCH);
+			}
+
+			return ApartmentPriceDto.builder()
+				.region(regionCode.getRegion()) // 예 : "서울"
+				.subregion(regionCode.getSubregion()) // 예 : "동남권"
+				.period((String) entry.get("PRD_DE")) // 예: "202504"
+				.price(Double.parseDouble((String) entry.get("DT"))) // 예: "1639.3"
+				.unit((String) entry.get("UNIT_NM")) // 예: "만원/m^2"
+				.build();
+		} catch (CustomException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.EXTERNAL_API_FAILURE);
+		}
+	}
+
+	private String buildUrl(int months) {
+		return BASE_URL +
+			DEFAULT_PARAMS +
+			"&newEstPrdCnt=" + months +
+			"&apiKey=" + apiKey;
+	}
+
+	public double getAnnualGrowthRate(String subregion) {
+		// 추후 구현
+		return 0.04; // 예시: 4% 상승률
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,7 @@ jwt.secret.key=${JWT_KEY:VEVTVF9ERUZBVUxUX0tFWV9hc2RsanF3ZWxrMSQyaW9jbnhhc2RAIzU
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG
 #spring.mvc.log-request-details=true
+logging.level.org.example.lifechart.domain.goal.repository=DEBUG
 
 # init data insert
 init.enabled=true

--- a/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
@@ -1,0 +1,109 @@
+package org.example.lifechart.domain.goal.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.example.lifechart.domain.goal.repository.ApartmentPriceCacheRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CachedApartmentPriceServiceTest {
+
+	@Mock
+	private ApartmentPriceCacheRepository redisRepository;
+
+	@Mock
+	private OpenApiApartmentPriceService openApiService;
+
+	@InjectMocks
+	private CachedApartmentPriceService service;
+
+	@Test
+	@DisplayName("캐시에 데이터가 있는 경우, OpenAPI를 호출하지 않고 가격을 반환한다.")
+	void getAveragePrice_캐시에_있으면_OpenAPI를_호출하지_않는다() {
+		// given
+		String region = "서울";
+		String subregion = "서남권";
+		Long area = 100L;
+		ApartmentPriceDto cachedDto = ApartmentPriceDto.builder()
+			.region(region)
+			.subregion(subregion)
+			.price(1500.0)
+			.unit("만원/m^2")
+			.period("202505")
+			.build();
+
+		given(redisRepository.find(region,subregion)).willReturn(Optional.of(cachedDto));
+
+		// when
+		Long result = service.getAveragePrice(region, subregion, area);
+
+		// then
+		verify(redisRepository).find(region,subregion);
+		assertThat(result).isEqualTo(1500L * 100L * 10_000L);
+	}
+
+	@Test
+	@DisplayName("캐시에 데이터가 없으면 OpenAPI를 호출해 데이터를 저장하고, 가격을 반환한다.")
+	void getAveragePrice_캐시에_데이터가_없으면_OpenAPI를_호출하고_데이터를_저장한뒤_가격을_반환한다() {
+		// given
+		String region = "서울";
+		String subregion = "동남권";
+		Long area = 50L;
+		ApartmentPriceDto apiDto = ApartmentPriceDto.builder()
+			.region(region)
+			.subregion(subregion)
+			.price(2000.0)
+			.unit("만원/m^2")
+			.period("202505")
+			.build();
+
+		given(redisRepository.find(region, subregion)).willReturn(Optional.empty());
+		given(openApiService.fetchLatest(region, subregion)).willReturn(apiDto);
+
+		// when
+		Long result = service.getAveragePrice(region, subregion, area);
+
+		// then
+		verify(redisRepository).find(region, subregion);
+		assertThat(result).isEqualTo(2000L * 50L * 10_000L);
+	}
+
+	@Test
+	@DisplayName("미래 가격 예측은 현재가에 복리 공식을 적용한다.")
+	void getFuturePredictedPrice_N년뒤_금액의_복리_계산결과를_반환한다() {
+		// given
+		String region = "서울";
+		String subregion = "도심";
+		Long area = 84L;
+		int yearsLater = 10;
+		double rate = 0.03; // 연 평균 CAGR 3%
+		ApartmentPriceDto dto = ApartmentPriceDto.builder()
+			.region(region)
+			.subregion(subregion)
+			.price(2_000L)
+			.unit("만원/m^2")
+			.period("202505")
+			.build();
+
+		given(redisRepository.find(region, subregion)).willReturn(Optional.of(dto));
+		given(openApiService.getAnnualGrowthRate(subregion)).willReturn(rate);
+
+		// when
+		Long result = service.getFuturePredictedPrice(region, subregion, area, yearsLater);
+
+		// then
+		Long expected = Math.round(2_000L * 10L * 10_000L *Math.pow(1+rate, yearsLater));
+
+		verify(redisRepository).find(region, subregion);
+		assertThat(result).isEqualTo(expected);
+	}
+}

--- a/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
@@ -79,11 +79,11 @@ public class CachedApartmentPriceServiceTest {
 
 	@Test
 	@DisplayName("미래 가격 예측은 현재가에 복리 공식을 적용한다.")
-	void getFuturePredictedPrice_N년뒤_금액의_복리_계산결과를_반환한다() {
+	void getFuturePredictedPrice_현재_가격에_복리_계산한_결과를_반환한다() {
 		// given
 		String region = "서울";
 		String subregion = "도심";
-		Long area = 84L;
+		Long area = 100L;
 		int yearsLater = 10;
 		double rate = 0.03; // 연 평균 CAGR 3%
 		ApartmentPriceDto dto = ApartmentPriceDto.builder()
@@ -101,7 +101,7 @@ public class CachedApartmentPriceServiceTest {
 		Long result = service.getFuturePredictedPrice(region, subregion, area, yearsLater);
 
 		// then
-		Long expected = Math.round(2_000L * 10L * 10_000L *Math.pow(1+rate, yearsLater));
+		Long expected = Math.round(2_000L * 100L * 10_000L *Math.pow(1+rate, yearsLater));
 
 		verify(redisRepository).find(region, subregion);
 		assertThat(result).isEqualTo(expected);

--- a/src/test/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/GoalHousingApartmentCalculateServiceTest.java
@@ -18,31 +18,63 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class GoalHousingApartmentCalculateServiceTest {
 
 	@Mock
-	private JsonApartmentPriceService apartmentPriceService;
+	private CachedApartmentPriceService apartmentPriceService;
 
 	@InjectMocks
 	private GoalHousingApartmentCalculateService goalCalculateService;
 
 	@Test
-	@DisplayName("주거 목표 금액 계산이 올바르게 수행된다")
-	void 주거목표_금액이_올바르게_계산된다() {
+	@DisplayName("주거 목표의 종료 시점이 1년 이상 이후인 경우 미래 금액을 예측하여 반환한다.")
+	void calculateTargetAmount_종료_시점이_1년_이상_이후이면_미래_시점의_주거목표_금액을_계산한다() {
 		// given
 		GoalHousingCalculateRequest housingDetail = GoalHousingCalculateRequest.builder()
+			.startAt(LocalDateTime.of(2025,8,1,0,0))
+			.endAt(LocalDateTime.of(2030,8,1,0,0))
 			.region("서울")
 			.subregion("서남권")
 			.area(100L)
 			.housingType(HousingType.APARTMENT)
-			.endAt(LocalDateTime.now())
 			.build();
+		int yearsLater = 5;
+		long expectedPrice = 2_000_000_000L; // 임의 가격
 
-		// Mocking
-		given(apartmentPriceService.getAveragePrice("서울", "서남권", 100L)).willReturn(143_210L);
+		given(apartmentPriceService.getFuturePredictedPrice("서울", "서남권", 100L, yearsLater)).willReturn(expectedPrice);
 
 		// when
 		Long result = goalCalculateService.calculateTargetAmount(housingDetail);
 
 		// then
-		Long expected = Math.round(1432.1 * housingDetail.getArea());
-		assertThat(result).isEqualTo(expected);
+		assertThat(result).isEqualTo(expectedPrice);
+	}
+
+	@Test
+	@DisplayName("주거 목표의 종료 시점이 1년 미만인 경우 현재 금액을 반환한다.")
+	void calculateTargetAmount_종료_시점이_1년_미만의_미래_시점이면_현재기준_금액을_계산한다() {
+		// given
+		GoalHousingCalculateRequest housingDetail = GoalHousingCalculateRequest.builder()
+			.startAt(LocalDateTime.of(2025,8,1,0,0))
+			.endAt(LocalDateTime.of(2025,10,31,0,0))
+			.region("서울")
+			.subregion("서남권")
+			.area(100L)
+			.housingType(HousingType.APARTMENT)
+			.build();
+
+		Long expectedPrice = 1_400_000_000L;
+
+		given(apartmentPriceService.getAveragePrice("서울", "서남권", 100L)).willReturn(expectedPrice);
+
+		// when
+		Long result = goalCalculateService.calculateTargetAmount(housingDetail);
+
+		// then
+		assertThat(result).isEqualTo(expectedPrice);
+	}
+
+	@Test
+	@DisplayName("housingType이 APARTMENT인 경우에만 true를 반환한다")
+	void supports_housingType이_APARTMENT일_때만_true를_반환한다() {
+		assertThat(goalCalculateService.supports(HousingType.APARTMENT)).isTrue();
+		assertThat(goalCalculateService.supports(HousingType.VILA)).isFalse();
 	}
 }

--- a/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
@@ -93,9 +93,9 @@ public class GoalServiceImplTest {
 			.share(Share.PRIVATE)
 			.build();
 
-		Goal goal = request.toEntity(user);
+		Goal goal = Goal.from(request, user);
 		goal = goal.toBuilder().id(1L).build();
-		GoalRetirement goalRetirement = detail.toEntity(goal, user.getBirthDate().getYear());
+		GoalRetirement goalRetirement = GoalRetirement.from(goal, detail, user.getBirthDate().getYear());
 		goalRetirement = goalRetirement.toBuilder().id(1L).build();
 
 		given(userRepository.findByIdAndDeletedAtIsNull(user.getId())).willReturn(Optional.of(user));
@@ -144,9 +144,9 @@ public class GoalServiceImplTest {
 			.share(Share.PRIVATE)
 			.build();
 
-		Goal goal = request.toEntity(user);
+		Goal goal = Goal.from(request, user);
 		goal = goal.toBuilder().id(1L).build();
-		GoalHousing goalHousing = detail.toEntity(goal);
+		GoalHousing goalHousing = GoalHousing.from(goal, detail);
 		goalHousing = goalHousing.toBuilder().id(1L).build();
 
 		given(userRepository.findByIdAndDeletedAtIsNull(user.getId())).willReturn(Optional.of(user));
@@ -193,9 +193,9 @@ public class GoalServiceImplTest {
 			.share(Share.PRIVATE)
 			.build();
 
-		Goal goal = request.toEntity(user);
+		Goal goal = Goal.from(request, user);
 		goal = goal.toBuilder().id(1L).build();
-		GoalEtc goalEtc = detail.toEntity(goal);
+		GoalEtc goalEtc = GoalEtc.from(goal, detail);
 		goalEtc = goalEtc.toBuilder().id(1L).build();
 
 		given(userRepository.findByIdAndDeletedAtIsNull(user.getId())).willReturn(Optional.of(user));

--- a/src/test/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceServiceTest.java
@@ -1,0 +1,56 @@
+package org.example.lifechart.domain.goal.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+public class OpenApiApartmentPriceServiceTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	@InjectMocks
+	private OpenApiApartmentPriceService service;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(service, "apiKey", "mock-api-key");
+		ReflectionTestUtils.setField(service, "objectMapper", new ObjectMapper());
+	}
+
+	@Test
+	@DisplayName("최근 아파트 시세를 정상적으로 파싱한다.")
+	void fetchLatest_해당_지역의_최근_아파트_시세를_정상적으로_파싱한다() {
+		// given
+		String region = "서울";
+		String subregion = "동남권";
+
+		String dummyJson = "[{\"C1\":\"0303\", \"C1_NM\":\"동남권\", \"PRD_DE\":\"202505\", \"DT\":\"1639.3\", \"UNIT_NM\":\"만원/m^2\"}]";
+
+		given(restTemplate.getForObject(anyString(), eq(String.class))).willReturn(dummyJson);
+
+		// when
+		ApartmentPriceDto result = service.fetchLatest(region, subregion);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getRegion()).isEqualTo("서울");
+		assertThat(result.getSubregion()).isEqualTo("동남권");
+		assertThat(result.getPeriod()).isEqualTo("202505");
+		assertThat(result.getPrice()).isEqualTo(1639.3);
+		assertThat(result.getUnit()).isEqualTo("만원/m^2");
+	}
+}


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #64 
- Closes #66 

## ✨ 변경 사항
[Controller]
1. GoalController
- API 통합(이전 커밋에서 현재 시점 계산/미래 시점 계산을 API로 분리했으나, API는 통합하고 서비스 레이어에서 분기 처리)

[Service]
1. GoalHousingApartmentCalculateService
- 서비스 내부의 메서드 분리를 calculateTargetAmount 메서드로 통합하고, 현재 시점/ 미래 시점을 분기 처리하기 위한 private 메서드 추가

2. OpenApiApartmentPriceService
- OpenAPI 경로로 데이터를 조회하고 파싱해 ApartmentPriceDto 형태로 변환하는 메서드 구현
- 최근 60개월 -> 120개월 데이터 불러오기. 최대 10년의 기간 중 N년의 기간을 선택해 평균상승률을 적용할 수 있도록 데이터 구간 확대
- 기존 OpenApiApartmentPriceService에 있던 getAnnualGrowthRate 메서드를 CachedApartmentPriceService로 옮기고 로직 업데이트

3. CachedApartmentPriceService
- OpenAPI에저 조회하고 파싱한 데이터를 Redis Repository에 저장하고, 값을 조회해 반환하는 메서드 구현
- calculateAnnualGrowthRate 메서드 구현: ApartmentPriceCacheRepository의 findStartAndEnd 로직으로 years 기간 동안의 가장 최신/오래된 데이터를 Pair로 매칭하고 years 기간 동안의 가격 평균 상승률(CAGR)을 계산하는 메서드


[Dto]
1. ApartmentPriceDto
- OpenAPI에서 제공하는 코드를 바탕으로 region, subregion, price, unit 등을 파싱해 활용하기 쉬운 형태로 반환하는 dto 설계

[Enums]
1. RegionCode
- ApartmentPriceDto에 매칭하기 위한 지역명, 코드, region, subregion을 정리한 enum 클래스 설계

[Repository]
1. ApartmentPriceCacheRepository
- Redis Cache를 활용하기 위한 Repository 인터페이스(조회, 저장 메서드 정의)
- findStartAndEnd :  years 기간의 가장 최신/ 오래된 데이터를 조회해 Pair로 매칭하는 메서드 구현

2. RedisApartmentPRiceRepository
- ApartmentPriceCacheRepository를 상속 받아, region, subregion을 기준으로 ApartmentPriceDto에서 값을 조회하고, 저장하는 Repository
- generateKey에 period 항목 추가
- findLatestPeriod : 각 region, subregion별 가장 최신 데이터 불러오기 (현재 시점과 데이터 상 가장 최신 시점이 다르기 때문에 필요한 메서드)


[Scheduler]
- ApartmentPriceSyncScheduler : 매달 1일 00시 00분에 OpenApiApartmentPriceService를 호출해 fatchLatest 메서드를 실행시켜 redis Cache 내 데이터를 갱신하는 스케줄러 구현

[Test]
1. GoalHousingApartmentCalculateServiceTest
- 목표 시점이 1년 이상/ 1년 미만인 경우 각각에 대해 메서드 분기처리가 잘 되는지 테스트 코드 작성

2. CachedApartmentPriceServiceTest
- 캐시에 있을 때는 OpenApi를 호출하지 않고, 캐시에 없을 때 OpenApi를 호출하고 저장한 뒤 값을 계산하는 로직의 테스트 코드 작성
- CachedApartmentPriceServiceTest : 가장 최신/오래된 시점의 캐시 데이터(ApartmentPriceDto) 생성 후 기간 동안의 CAGR을 계산해 yearsLater 시점의 예상 가격 반환하는 메서드(리팩토링) 구현

3. OpenApiApartmentPriceServiceTest
- Json에서 해당 지역의 최근 아파트 시세를 정상적으로 파싱해 ApartmentPriceDto 형식으로 반환하는 로직 테스트 코드 작성

[Config]
1. RedisConfig
- Redis의 key, value, hash타입 key, hash타입 value를 그대로 문자열로 저장되도록 명시적으로 설정

## 📷 Postman 
- GoalHousingApartmentPriceSeriveTest
![image](https://github.com/user-attachments/assets/a5862e8d-200b-4aad-ae4a-f21083d81542)

- OpenApiApartmentPriceServiceTest
![image](https://github.com/user-attachments/assets/663825e6-96bf-437b-8d5f-dc083193d1a0)

- CachedApartmentPriceServiceTest
![image](https://github.com/user-attachments/assets/e952cf9e-60f6-493e-83b3-f8bad71cd417)

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
