### PR TITLE
[feat] 이벤트 발행/구독 케이스 추가(목표 생성/ 회원가입)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,4 +155,3 @@ checkstyle {
     // configProperties: 룰 중 예외 규칙(suppression) 지정 파일
     toolVersion = "8.24" // toolVersion: 사용할 Checkstyle 버전 지정 (8.24)
 }
-

--- a/src/main/java/org/example/lifechart/adapter/in/AccountCreatedEventListener.java
+++ b/src/main/java/org/example/lifechart/adapter/in/AccountCreatedEventListener.java
@@ -1,0 +1,29 @@
+package org.example.lifechart.adapter.in;
+
+import org.example.lifechart.domain.goal.service.DefaultRetirementGoalService;
+import org.example.lifechart.domain.user.dto.AccountCreatedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccountCreatedEventListener {
+
+	private final DefaultRetirementGoalService defaultRetirementGoalService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountCreatedEvent event) {
+		try {
+			defaultRetirementGoalService.createDefaultRetirementGoal(event.getUserId());
+		} catch (Exception e) {
+			log.warn("기본 은퇴 목표 생성 실패 - userId={}", event.getUserId(), e);
+		}
+	}
+}

--- a/src/main/java/org/example/lifechart/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/lifechart/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.example.lifechart.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalUpdateRequest.java
+++ b/src/main/java/org/example/lifechart/domain/goal/dto/request/GoalUpdateRequest.java
@@ -1,6 +1,7 @@
 package org.example.lifechart.domain.goal.dto.request;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.example.lifechart.domain.goal.enums.Share;
@@ -38,8 +39,8 @@ public class GoalUpdateRequest implements HaSGoalPeriod, TagValidatable {
 	@NotNull(message = "종료일은 필수 입력입니다.")
 	private LocalDateTime endAt;
 
-	@Schema(description = "생성할 목표와 연동할 시뮬레이션 ID 목록(선택 사항)", example = "[11, 19, 21]")
-	private List<Long> simulationIds;
+	@Schema(description = "수정할 목표와 연동할 시뮬레이션 ID 목록(선택 사항)", example = "[11, 19, 21]")
+	private List<Long> simulationIds = new ArrayList<>();
 
 	@Schema(description = "카테고리별 상세 정보", example = "housing: {} / retirement : {} / etc: {}")
 	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)

--- a/src/main/java/org/example/lifechart/domain/goal/event/GoalCreatedEvent.java
+++ b/src/main/java/org/example/lifechart/domain/goal/event/GoalCreatedEvent.java
@@ -1,12 +1,14 @@
 package org.example.lifechart.domain.goal.event;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class GoalDeletedEvent {
-
+public class GoalCreatedEvent {
 	private final Long userId;
 	private final Long goalId;
+	private final List<Long> simulationIds;
 }

--- a/src/main/java/org/example/lifechart/domain/goal/event/GoalUpdatedEvent.java
+++ b/src/main/java/org/example/lifechart/domain/goal/event/GoalUpdatedEvent.java
@@ -1,5 +1,7 @@
 package org.example.lifechart.domain.goal.event;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +11,5 @@ public class GoalUpdatedEvent {
 
 	private final Long userId;
 	private final Long goalId;
+	private final List<Long> simulationIds;
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
@@ -22,6 +22,7 @@ import org.example.lifechart.domain.goal.entity.GoalHousing;
 import org.example.lifechart.domain.goal.entity.GoalRetirement;
 import org.example.lifechart.domain.goal.enums.Category;
 import org.example.lifechart.domain.goal.enums.Status;
+import org.example.lifechart.domain.goal.event.GoalCreatedEvent;
 import org.example.lifechart.domain.goal.event.GoalDeletedEvent;
 import org.example.lifechart.domain.goal.event.GoalUpdatedEvent;
 import org.example.lifechart.domain.goal.fetcher.GoalDetailFetcherFactory;
@@ -66,6 +67,13 @@ public class GoalServiceImpl implements GoalService {
 		Goal newGoal = Goal.from(requestDto, user);
 		Goal savedGoal = goalRepository.save(newGoal);
 		saveGoalDetail(detail, savedGoal, user);
+
+		// 목표 생성 이벤트를 발행하고, 구독하는 쪽에서 카테고리에 따라 다른 로직 수행
+		try {
+			eventPublisher.publishEvent(new GoalCreatedEvent(savedGoal.getUser().getId(), savedGoal.getId(), requestDto.getSimulationIds()));
+		} catch (Exception e) {
+			log.warn(ErrorCode.GOAL_CREATE_EVENT_PUBLISH_FAILED.getMessage());
+		}
 
 		return GoalResponse.from(savedGoal);
 	}
@@ -112,7 +120,7 @@ public class GoalServiceImpl implements GoalService {
 		goal.delete();
 
 		try {
-			eventPublisher.publishEvent(new GoalDeletedEvent(goal.getId()));
+			eventPublisher.publishEvent(new GoalDeletedEvent(goal.getUser().getId(), goal.getId()));
 		} catch (Exception e) {
 			log.warn(ErrorCode.GOAL_DELETE_EVENT_PUBLISH_FAILED.getMessage());
 		}
@@ -134,7 +142,7 @@ public class GoalServiceImpl implements GoalService {
 		updateGoalDetail(detail, savedGoal.getId(), user); // 목표 상세 수정 Entity > DB 갱신
 
 		try {
-			eventPublisher.publishEvent(new GoalUpdatedEvent(savedGoal.getId()));
+			eventPublisher.publishEvent(new GoalUpdatedEvent(savedGoal.getUser().getId(), savedGoal.getId(), request.getSimulationIds()));
 		} catch (Exception e) {
 			log.warn(ErrorCode.GOAL_UPDATE_EVENT_PUBLISH_FAILED.getMessage());
 		}

--- a/src/main/java/org/example/lifechart/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,8 @@
 package org.example.lifechart.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
 import org.example.lifechart.domain.user.port.AccountEventPublisherPort;
@@ -8,10 +10,12 @@ import org.example.lifechart.common.port.SendSqsPort;
 import org.example.lifechart.domain.user.dto.*;
 import org.example.lifechart.domain.user.entity.User;
 import org.example.lifechart.domain.user.repository.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,6 +25,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final SendSqsPort sqsPort;
     private final AccountEventPublisherPort accountEventPublisherPort;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public User signup(SignupRequest request) {
@@ -33,15 +38,15 @@ public class UserServiceImpl implements UserService {
         User savedUser = userRepository.save(user);
 
         // SNS 발행
-        accountEventPublisherPort.publishAccountCreatedEvent(
-                new AccountCreatedEvent(
-                        savedUser.getId(),
-                        savedUser.getEmail(),
-                        savedUser.getNickname(),
-                        savedUser.getName(),
-                        savedUser.getCreatedAt().toString()
-                )
+        AccountCreatedEvent event = new AccountCreatedEvent(
+            savedUser.getId(),
+            savedUser.getEmail(),
+            savedUser.getNickname(),
+            savedUser.getName(),
+            savedUser.getCreatedAt().toString()
         );
+
+        accountEventPublisherPort.publishAccountCreatedEvent(event);
 
         // 알림 SQS 전송
         sqsPort.sendNotification(
@@ -50,6 +55,12 @@ public class UserServiceImpl implements UserService {
                 "Welcome!",
                 "가입을 축하합니다!"
         );
+
+        try {
+            eventPublisher.publishEvent(event);
+        } catch (Exception e) {
+            log.warn("회원가입 Spring 이벤트 발행 실패 : {}", e.getMessage(), e);
+        }
 
         return savedUser;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,4 @@ aws.key.access.secret=0
 aws.key.access.id=0
 openapi.kosis.key=0
 
+mock-bank.url=http://localhost:8081

--- a/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +28,7 @@ import org.example.lifechart.domain.goal.enums.HousingType;
 import org.example.lifechart.domain.goal.enums.RetirementType;
 import org.example.lifechart.domain.goal.enums.Share;
 import org.example.lifechart.domain.goal.enums.Status;
+import org.example.lifechart.domain.goal.event.GoalCreatedEvent;
 import org.example.lifechart.domain.goal.event.GoalDeletedEvent;
 import org.example.lifechart.domain.goal.event.GoalUpdatedEvent;
 import org.example.lifechart.domain.goal.fetcher.GoalDetailFetcherFactory;
@@ -225,6 +227,62 @@ public class GoalServiceImplTest {
 		assertThat(response.getGoalId()).isEqualTo(1L);
 	}
 
+	@Test
+	@DisplayName("은퇴 목표 생성과 이벤트 발행에 성공한다.")
+	void createGoal_은퇴_목표_생성과_이벤트_발행에_성공한다() {
+		// given
+		User user = User.builder()
+			.id(1L)
+			.gender("male")
+			.birthDate(LocalDate.of(1990,01,01))
+			.isDeleted(false)
+			.build();
+
+		GoalRetirementRequest detail = GoalRetirementRequest.builder()
+			.expectedLifespan(90L)
+			.monthlyExpense(2_000_000L)
+			.retirementType(RetirementType.COUPLE)
+			.build();
+
+		LocalDateTime currentTime = LocalDateTime.now();
+
+		GoalCreateRequest request = GoalCreateRequest.builder()
+			.title("젊은 한량 되기")
+			.category(Category.RETIREMENT)
+			.startAt(currentTime)
+			.endAt(currentTime.plusMonths(6))
+			.detail(detail)
+			.targetAmount(502_000_000L)
+			.simulationIds(new ArrayList<>())
+			.share(Share.PRIVATE)
+			.build();
+
+		Goal goal = Goal.from(request, user);
+		goal = goal.toBuilder().id(1L).build();
+		GoalRetirement goalRetirement = GoalRetirement.from(goal, detail, user.getBirthDate().getYear());
+		goalRetirement = goalRetirement.toBuilder().id(1L).build();
+
+		given(userRepository.findByIdAndDeletedAtIsNull(user.getId())).willReturn(Optional.of(user));
+		given(goalRepository.save(any())).willReturn(goal);
+		given(goalRetirementRepository.save(any())).willReturn(goalRetirement);
+		ArgumentCaptor<GoalCreatedEvent> captor = ArgumentCaptor.forClass(GoalCreatedEvent.class);
+
+		// when
+		GoalResponse response = goalService.createGoal(request, user.getId());
+
+		// then
+		verify(userRepository).findByIdAndDeletedAtIsNull(user.getId());
+		verify(goalRepository).save(any(Goal.class));
+		verify(goalRetirementRepository).save(any(GoalRetirement.class));
+		verify(eventPublisher).publishEvent(captor.capture());
+		assertThat(captor.getValue().getGoalId()).isEqualTo(response.getGoalId());
+		assertThat(captor.getValue().getSimulationIds().size()).isEqualTo(0L);
+
+		assertThat(goal.getTitle()).isEqualTo("젊은 한량 되기");
+		assertThat(goalRetirement.getGoal()).isEqualTo(goal);
+		assertThat(response.getGoalId()).isEqualTo(1L);
+	}
+
 	@Test // to do
 	@DisplayName("목표의 category와 detail의 입력 양식이 다르면 예외를 던진다.")
 	void createGoal_목표의_category와_detail의_양식이_다르면_GOAL_CATEGORY_DETAIL_MISMATCH_예외를_던진다() {
@@ -358,7 +416,9 @@ public class GoalServiceImplTest {
 		User user = User.builder()
 			.id(1L)
 			.build();
+
 		Goal goal = Goal.builder()
+			.user(user)
 			.id(1L)
 			.status(Status.ACTIVE)
 			.build();
@@ -372,6 +432,7 @@ public class GoalServiceImplTest {
 
 		// then
 		verify(eventPublisher).publishEvent(captor.capture());
+		assertThat(captor.getValue().getUserId()).isEqualTo(1L);
 		assertThat(captor.getValue().getGoalId()).isEqualTo(1L);
 		verify(userRepository).findByIdAndDeletedAtIsNull(user.getId());
 		verify(goalRepository).findByIdAndUserId(goal.getId(), user.getId());
@@ -667,6 +728,7 @@ public class GoalServiceImplTest {
 			.endAt(currentTime.plusMonths(6))
 			.detail(detail)
 			.targetAmount(1_432_100_000L)
+			.simulationIds(List.of(1L, 2L))
 			.share(Share.PRIVATE)
 			.build();
 
@@ -687,6 +749,7 @@ public class GoalServiceImplTest {
 		verify(eventPublisher).publishEvent(captor.capture());
 		GoalUpdatedEvent event = captor.getValue();
 		assertThat(event.getGoalId()).isEqualTo(1L);
+		assertThat(event.getSimulationIds().size()).isEqualTo(2L);
 
 		assertThat(response.getGoalId()).isEqualTo(1L);
 		assertThat(goal.getTitle()).isEqualTo("여의도 집 사기");


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #87 

## ✨ 변경 사항
[Service]
1. GoalServiceImpl :
- ApplicationEventPublisher 클래스 속성 추가
- 목표 생성 시 이벤트 발행 메서드 추가
- 목표 수정/삭제 시 이벤트 발행 필드 수정

2. UserServiceImpl
- SNS 발행 / Spring event 발행 리팩토링

[Test]
1. 이벤트 정상 발행 확인

[Event&Request]
1. GoalUpdatedEvent 내 simulationIds 필드 추가
2. GoalUpdateRequest 내 simulationIds 기본 리스트 반환타입 추가
3. GoalCreatedEvent : 목표 생성 시 시뮬레이션 생성/수정을 위한 이벤트 클래스 구현

[Adapter]
1. AccountCreatedEventListener 클래스 구현

[Config]
1. @Async 어노테이션 사용을 위한 AsyncConfig 클래스 구현

## 📷 Postman 
- 목표 수정과 이벤트 발행 성공케이스
![image](https://github.com/user-attachments/assets/ef4c12ef-45f4-4e80-92ae-ed7f9270c0b7)

- 목표 생성과 이벤트 발행 성공케이스
![image](https://github.com/user-attachments/assets/a20539ec-5952-4781-97bf-f4e66b42a04c)

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
