### PR TITLE
[refactor] OpenApiApartmentPriceService 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,9 @@ dependencies {
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
         }
     }
+
+    // utility
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/lifechart/common/config/RestTemplateConfig.java
+++ b/src/main/java/org/example/lifechart/common/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package org.example.lifechart.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class RestTemplateConfig {
 
 	@Bean
 	public RestTemplate restTemplate() {
-		return new RestTemplate();
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(5000); // 연결 타임아웃 (ms)
+		factory.setReadTimeout(5000); // 읽기 타임아웃 (ms)
+		return new RestTemplate(factory);
 	}
 }

--- a/src/main/java/org/example/lifechart/common/response/ApiResponse.java
+++ b/src/main/java/org/example/lifechart/common/response/ApiResponse.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 public class ApiResponse<T> {
     private final Boolean isSuccess;        // 성공 여부
     private final String message;           // 응답 메시지
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final ErrorCode errorCode;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T payload;                // 실제 응답 데이터 (성공 시 포함)

--- a/src/main/java/org/example/lifechart/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/lifechart/domain/comment/repository/CommentRepository.java
@@ -4,10 +4,15 @@ import java.util.Optional;
 
 import org.example.lifechart.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
 	@Query("SELECT c.goal.id FROM Comment c WHERE c.id = :commentId")
 	Optional<Long> findGoalIdByCommentId(@Param("commentId") Long commentId);
+
+	@Modifying
+	@Query("DELETE FROM Comment c WHERE c.goal.id =:goalId")
+	void deleteAllByGoalId(@Param("goalId")Long goalId);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
+++ b/src/main/java/org/example/lifechart/domain/goal/controller/GoalController.java
@@ -22,6 +22,7 @@ import org.example.lifechart.domain.goal.service.GoalRetirementCalculateService;
 import org.example.lifechart.domain.goal.service.GoalServiceImpl;
 import org.example.lifechart.domain.goal.service.RetirementReferenceValueService;
 import org.example.lifechart.security.CustomUserPrincipal;
+import org.example.lifechart.validation.annotation.ValidGoalPeriod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -65,7 +66,7 @@ public class GoalController {
 	// 은퇴 목표 금액 계산 API (값 입력 후 프론트에서 '계산' 버튼 클릭 시 호출됩니다.)
 	@PostMapping("/retirement/calculate")
 	public ResponseEntity<ApiResponse<Long>> calculateRetirementTargetAmount(
-		@RequestBody GoalRetirementCalculateRequest request,
+		@Valid @RequestBody GoalRetirementCalculateRequest request,
 		@AuthenticationPrincipal CustomUserPrincipal principal
 	) {
 		Long calculatedTargetAmount = goalRetirementCalculateService.calculateTargetAmount(request, principal.getUserId());
@@ -79,7 +80,7 @@ public class GoalController {
 	)
 	@PostMapping("/housing/calculate")
 	public ResponseEntity<ApiResponse<Long>> calculateHousingTargetAmount(
-		@RequestBody GoalHousingCalculateRequest request,
+		@Valid @RequestBody GoalHousingCalculateRequest request,
 		@AuthenticationPrincipal CustomUserPrincipal principal
 	) {
 		Long targetAmount = goalHousingCalculateService.calculateTargetAmount(request);
@@ -157,7 +158,7 @@ public class GoalController {
 	public ResponseEntity<ApiResponse<GoalResponse>> updateGoal(
 		@PathVariable Long goalId,
 		@AuthenticationPrincipal CustomUserPrincipal principal,
-		@RequestBody GoalUpdateRequest request
+		@Valid @RequestBody GoalUpdateRequest request
 	) {
 		GoalResponse response = goalService.updateGoal(request, goalId, principal.getUserId());
 		return ApiResponse.onSuccess(SuccessCode.GOAL_UPDATE_SUCCESS, response);

--- a/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
+++ b/src/main/java/org/example/lifechart/domain/goal/entity/Goal.java
@@ -130,4 +130,12 @@ public class Goal extends BaseEntity {
 			this.likeCount--;
 		}
 	}
+
+	public void clearComment() {
+		this.commentCount = 0;
+	}
+
+	public void clearLike() {
+		this.likeCount = 0;
+	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/ApartmentPriceCacheRepository.java
@@ -6,7 +6,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
 
 public interface ApartmentPriceCacheRepository {
-	Optional<ApartmentPriceDto> find(String region, String subregion);
-	Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion, int years);
+	Optional<ApartmentPriceDto> findOldest(String region, String subregion);
+	Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion); // start-end 쌍 조회
+	Optional<ApartmentPriceDto> findLatest(String region, String subregion);
 	void save(ApartmentPriceDto dto);
+	void saveWithAlias(ApartmentPriceDto dto, boolean isStart);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/GoalRepository.java
@@ -37,4 +37,11 @@ public interface GoalRepository extends JpaRepository<Goal, Long>,
     WHERE g.id IN :goalIds AND g.user.id = :userId
     """)
     List<Goal> findAllWithUserByIdAndUserId(@Param("goalIds") List<Long> goalIds, @Param("userId") Long userId);
+
+    List<Goal> findAllById(Iterable<Long> ids);
+
+    @Query("SELECT g.category FROM Goal g WHERE g.id = :goalId")
+    Optional<Category> findCategoryById(@Param("goalId") Long goalId);
+
+    Optional<Goal> findByIdAndUserIdAndStatus(Long id, Long userId, Status status);
 }

--- a/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
+++ b/src/main/java/org/example/lifechart/domain/goal/repository/RedisApartmentPriceRepository.java
@@ -1,21 +1,11 @@
 package org.example.lifechart.domain.goal.repository;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.example.lifechart.common.enums.ErrorCode;
-import org.example.lifechart.common.exception.CustomException;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
-import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,104 +24,73 @@ public class RedisApartmentPriceRepository implements ApartmentPriceCacheReposit
 
 	private static final Duration TTL = Duration.ofDays(30); // 30일 캐시 유지
 
-	private String generateKey(String region, String subregion, String period) {
-		return "apt-price::" + region + "::" + subregion + "::" + period;
+	@Override
+	public Optional<ApartmentPriceDto> findOldest(String region, String subregion) {
+		String key = generateKey(region, subregion, "start");
+		return fetchFromRedis(key);
 	}
 
 	@Override
-	public Optional<ApartmentPriceDto> find(String region, String subregion) {
-		String key = generateKey(region, subregion, null);
-		String value = redisTemplate.opsForValue().get(key);
+	public Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion) {
 
-		if (value == null)
-			return Optional.empty();
+		String startKey = generateKey(region, subregion, "start");
+		String endKey = generateKey(region, subregion, "end");
 
 		try {
-			ApartmentPriceDto dto = objectMapper.readValue(value, ApartmentPriceDto.class);
-			return Optional.of(dto);
-		} catch (JsonProcessingException e) {
-			return Optional.empty(); // or Log error
-		}
-	}
-
-	@Override
-	public Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> findStartAndEnd(String region, String subregion, int years) {
-
-		// 1. 데이터 중 가장 최신 period 구하기
-		String latestPeriod = findLatestPeriod(region, subregion); // 예: "202504"
-		YearMonth end = YearMonth.parse(latestPeriod, DateTimeFormatter.ofPattern("yyyyMM"));
-		YearMonth start = end.minusYears(years);
-
-		String startKey = generateKey(region, subregion, start.format(DateTimeFormatter.ofPattern("yyyyMM")));
-		String endKey = generateKey(region, subregion, latestPeriod);
-
-		ApartmentPriceDto startDto = null;
-		ApartmentPriceDto endDto = null;
-
-		try {
-			String startJson = redisTemplate.opsForValue().get(startKey);
-			if (startJson != null) {
-				startDto = objectMapper.readValue(startJson, ApartmentPriceDto.class);
-			}
-
-			String endJson = redisTemplate.opsForValue().get(endKey);
-			if (endJson != null) {
-				endDto = objectMapper.readValue(endJson, ApartmentPriceDto.class);
-			}
+			ApartmentPriceDto startDto = fetchFromRedis(startKey).orElse(null);
+			ApartmentPriceDto endDto = fetchFromRedis(endKey).orElse(null);
 
 			if (startDto != null && endDto != null) {
 				return Optional.of(Pair.of(startDto, endDto));
 			}
 		} catch (Exception e) {
-			log.warn("Redis price fetch failed: {}", e.getMessage());
+			log.warn("Redis 가격 조회 실패: {}", e.getMessage());
 		}
 
 		return Optional.empty();
 	}
 
 	@Override
+	public Optional<ApartmentPriceDto> findLatest(String region, String subregion) {
+		String key = generateKey(region, subregion, "end"); // 최신 가격을 "end"키에 저장 중
+		return fetchFromRedis(key);
+	}
+
+	@Override
 	public void save(ApartmentPriceDto dto) {
 		String key = generateKey(dto.getRegion(), dto.getSubregion(), dto.getPeriod());
+		saveToRedis(key, dto);
+	}
+
+	@Override
+	public void saveWithAlias(ApartmentPriceDto dto, boolean isStart) {
+		String alias = isStart ? "start" : "end";
+		String key = generateKey(dto.getRegion(), dto.getSubregion(), alias);
+		saveToRedis(key, dto);
+	}
+
+	private String generateKey(String region, String subregion, String periodOrAlias) {
+		return String.format("apt-price:%s:%s:%s", region, subregion ,periodOrAlias);
+	}
+
+	private void saveToRedis(String key, ApartmentPriceDto dto) {
 		try {
 			String json = objectMapper.writeValueAsString(dto);
 			redisTemplate.opsForValue().set(key, json, TTL);
 		} catch (JsonProcessingException e) {
-			// Log error
+			log.warn("Redis 저장 실패. {} : {}", key, e.getMessage());
 		}
 	}
 
-	private String findLatestPeriod(String region, String subregion) {
-
-		String prefix = "apt-price::" + region + "::" + subregion + "::";
-		ScanOptions options = ScanOptions.scanOptions()
-			.match(prefix + "*")
-			.count(100)
-			.build();
-
-		Set<String> periods = new HashSet<>();
-
-		try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
-			.getConnection()
-			.scan(options)) {
-
-			while (cursor.hasNext()) {
-				String key = new String(cursor.next(), StandardCharsets.UTF_8); // byte[] -> String
-				String[] parts = key.split("::");
-				if (parts.length == 4) {
-					periods.add(parts[3]);
-				}
+	private Optional<ApartmentPriceDto> fetchFromRedis(String key) {
+		try {
+			String json = redisTemplate.opsForValue().get(key);
+			if (json != null) {
+				return Optional.of(objectMapper.readValue(json, ApartmentPriceDto.class));
 			}
-
 		} catch (Exception e) {
-			log.error("Redis SCAN 실패 : {}", e.getMessage(), e);
-			throw new CustomException(ErrorCode.EXTERNAL_API_FAILURE);
+			log.warn("Redis 읽기 실패. {}: {}", key, e.getMessage());
 		}
-
-		log.debug("Latest periods found for {}-{}: {}", region, subregion, periods);
-
-		// 최신 period 반환
-		return periods.stream()
-			.max(Comparator.naturalOrder()) // 문자열 정렬
-			.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+		return Optional.empty();
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/scheduler/ApartmentPriceSyncScheduler.java
+++ b/src/main/java/org/example/lifechart/domain/goal/scheduler/ApartmentPriceSyncScheduler.java
@@ -1,9 +1,8 @@
 package org.example.lifechart.domain.goal.scheduler;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
 import org.example.lifechart.domain.goal.enums.RegionCode;
 import org.example.lifechart.domain.goal.repository.ApartmentPriceCacheRepository;
@@ -24,18 +23,22 @@ public class ApartmentPriceSyncScheduler {
 
 	@Scheduled(cron = "0 0 0 1 * *")
 	public void sync() {
-		for (RegionCode code : RegionCode.getValidCodes()) {
-			String region = code.getRegion();
-			String subregion = code.getSubregion();
+		try {
+			Map<RegionCode, Pair<ApartmentPriceDto, ApartmentPriceDto>> allData = apiService.fetchDurationAll(120);
 
-			try {
-				ApartmentPriceDto dto = apiService.fetchLatest(region, subregion);
-				if (dto != null) {
-					redisRepository.save(dto);
-				}
-			} catch (Exception e) {
-				log.warn("Failed to fetch/save apartment price for region: {}, subregion: {}", region, subregion, e);
+			for (Map.Entry<RegionCode, Pair<ApartmentPriceDto, ApartmentPriceDto>> entry : allData.entrySet()) {
+				ApartmentPriceDto start = entry.getValue().getLeft();
+				ApartmentPriceDto end = entry.getValue().getRight();
+
+				redisRepository.save(start); // key: apt-price:서울:동남권:201507
+				redisRepository.save(end); // key: apt-price:서울:동남권:202507
+
+				redisRepository.saveWithAlias(start, true); // key: apt-price:서울:동남권:start
+				redisRepository.saveWithAlias(end, false); // key: apt-price:서울:동남권:end
 			}
+			log.info("아파트 가격 데이터 동기화 성공. 지역 수: {}", allData.size());
+		} catch (Exception e) {
+			log.error("아파트 가격 데이터 동기화 실패", e);
 		}
 	}
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceService.java
@@ -16,9 +16,9 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 	private final ApartmentPriceCacheRepository redisRepository;
 	private final OpenApiApartmentPriceService openApiService;
 
-	@Override // 현재 시점의 가격 계싼
+	@Override // 현재 시점의 가격 계산
 	public Long getAveragePrice(String region, String subregion, Long area) {
-		ApartmentPriceDto dto = redisRepository.find(region, subregion)
+		ApartmentPriceDto dto = redisRepository.findLatest(region, subregion)
 			.orElseGet(() -> {
 				ApartmentPriceDto fetched = openApiService.fetchLatest(region, subregion);
 				redisRepository.save(fetched);
@@ -27,7 +27,7 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 		return Math.round(dto.getPrice() * area * 10_000L); // price 단위가 만원으로, 원 단위 환산
 	}
 
-	@Override // 미래 시점의 가격 계싼
+	@Override // 미래 시점의 가격 계산
 	public Long getFuturePredictedPrice(String region, String subregion, Long area, int yearsLater) {
 		Long current = getAveragePrice(region, subregion, area);
 		double rate = calculateAnnualGrowthRate(region, subregion, 10);
@@ -36,7 +36,7 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 
 	private double calculateAnnualGrowthRate(String region, String subregion, int years) {
 		// 1. 과거 N년 데이터 중 가장 최신/오래된 데이터 가져오기
-		Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> pairOpt = redisRepository.findStartAndEnd(region, subregion, years);
+		Optional<Pair<ApartmentPriceDto, ApartmentPriceDto>> pairOpt = redisRepository.findStartAndEnd(region, subregion);
 
 		if (pairOpt.isEmpty()) return 0.03; // fallback
 
@@ -47,5 +47,4 @@ public class CachedApartmentPriceService implements ApartmentPriceService {
 		// 3. CAGR (복리 성장률) 계산
 		return Math.pow(end.getPrice() / start.getPrice(), 1.0/ years) - 1 ;
 	}
-
 }

--- a/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/GoalServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
+import org.example.lifechart.domain.comment.repository.CommentRepository;
 import org.example.lifechart.domain.goal.dto.request.GoalCreateRequest;
 import org.example.lifechart.domain.goal.dto.request.GoalDetailRequest;
 import org.example.lifechart.domain.goal.dto.request.GoalEtcRequest;
@@ -30,6 +31,7 @@ import org.example.lifechart.domain.goal.repository.GoalEtcRepository;
 import org.example.lifechart.domain.goal.repository.GoalHousingRepository;
 import org.example.lifechart.domain.goal.repository.GoalRepository;
 import org.example.lifechart.domain.goal.repository.GoalRetirementRepository;
+import org.example.lifechart.domain.like.repository.LikeRepository;
 import org.example.lifechart.domain.user.entity.User;
 import org.example.lifechart.domain.user.repository.UserRepository;
 import org.springframework.context.ApplicationEventPublisher;
@@ -51,6 +53,8 @@ public class GoalServiceImpl implements GoalService {
 	private final UserRepository userRepository;
 	private final GoalDetailFetcherFactory goalDetailFetcherFactory;
 	private final ApplicationEventPublisher eventPublisher;
+	private final CommentRepository commentRepository;
+	private final LikeRepository likeRepository;
 
 	@Transactional
 	@Override
@@ -117,6 +121,11 @@ public class GoalServiceImpl implements GoalService {
 			&& goalRepository.countByUserIdAndCategory(userId, Category.RETIREMENT) <= 1) {
 			throw new CustomException(ErrorCode.ONLY_ONE_RETIREMENT_GOAL);
 		}
+
+		commentRepository.deleteAllByGoalId(goal.getId());
+		goal.clearComment();
+		likeRepository.deleteAllByGoalId(goal.getId());
+		goal.clearLike();
 		goal.delete();
 
 		try {

--- a/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
@@ -73,6 +73,7 @@ public class OpenApiApartmentPriceService {
 
 			return mapToDto(latestEntry, regionCode);
 		} catch (CustomException e) {
+			log.warn("CustomException 발생: {}", e.getMessage(), e); // 로그 남기기
 			throw e;
 		} catch (Exception e) {
 			log.error("최신 아파트 가격을 호출하는 데 실패. 지역: {}, 세부지역: {}, 원인: {}",
@@ -105,8 +106,17 @@ public class OpenApiApartmentPriceService {
 					Map<String, Object> latest = regionData.stream()
 						.max(Comparator.comparing(item -> (String) item.get("PRD_DE"))).orElse(null); // 가장 최신 데이터 뽑기
 
-					return Map.entry(code,
-						Pair.of(mapToDto(oldest, code), mapToDto(latest, code)));
+
+					// null 체크 추가
+					if (oldest == null || latest == null) {
+						log.warn("oldest 혹은 latest 데이터가 없습니다. 지역: {}", code.name());
+						return null;
+					}
+
+					return Map.entry(code, Pair.of(
+						mapToDto(oldest, code),
+						mapToDto(latest, code)
+					));
 				})
 				.filter((Objects::nonNull))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
+++ b/src/main/java/org/example/lifechart/domain/goal/service/OpenApiApartmentPriceService.java
@@ -4,8 +4,10 @@ import java.net.SocketTimeoutException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
 import org.example.lifechart.domain.goal.dto.response.ApartmentPriceDto;
@@ -20,7 +22,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OpenApiApartmentPriceService {
@@ -53,36 +57,74 @@ public class OpenApiApartmentPriceService {
 			List<Map<String, Object>> dataList = objectMapper.readValue(response, new TypeReference<>() {});
 
 			// 최신 데이터 추출
-			Optional<Map<String, Object>> latestEntry = dataList.stream()
+			Map<String, Object> latestEntry = dataList.stream()
 				.filter(item -> subregion.equals(item.get("C1_NM")))
-				.max(Comparator.comparing(item -> (String) item.get("PRD_DE")));
-
-			if (latestEntry.isEmpty()) {
-				throw new CustomException(ErrorCode.DATA_NOT_FOUND);
-			}
-
-			Map<String, Object> entry = latestEntry.get();
+				.max(Comparator.comparing(item -> (String) item.get("PRD_DE")))
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
 
 			// 지역 코드 -> RegionCode enum 매핑
-			String code = (String) entry.get("C1"); //
-			RegionCode regionCode = RegionCode.fromCode(code);
+			RegionCode regionCode = RegionCode.fromCode((String) latestEntry.get("C1"));
 
 			if (!regionCode.getRegion().equals(region) || !regionCode.getSubregion().equals(subregion)) {
+				log.warn("지역 불일치. 기대값: {}:{}, 실제값: {}: {}",
+					region, subregion, regionCode.getRegion(), regionCode.getSubregion());
 				throw new CustomException(ErrorCode.INVALID_REGION_MATCH);
 			}
 
-			return ApartmentPriceDto.builder()
-				.region(regionCode.getRegion()) // 예 : "서울"
-				.subregion(regionCode.getSubregion()) // 예 : "동남권"
-				.period((String) entry.get("PRD_DE")) // 예: "202504"
-				.price(Double.parseDouble((String) entry.get("DT"))) // 예: "1639.3"
-				.unit((String) entry.get("UNIT_NM")) // 예: "만원/m^2"
-				.build();
+			return mapToDto(latestEntry, regionCode);
 		} catch (CustomException e) {
 			throw e;
 		} catch (Exception e) {
+			log.error("최신 아파트 가격을 호출하는 데 실패. 지역: {}, 세부지역: {}, 원인: {}",
+				region, subregion, e.getMessage());
 			throw new CustomException(ErrorCode.EXTERNAL_API_FAILURE);
 		}
+	}
+
+	/**
+	 *
+	 * @param months : N개월 동안의 데이터를 불러오기 위한 입력 필드
+	 * @return
+	 */
+	public Map<RegionCode, Pair<ApartmentPriceDto, ApartmentPriceDto>> fetchDurationAll(int months) {
+		String url = buildUrl(months);
+		try {
+			String response = restTemplate.getForObject(url, String.class);
+			List<Map<String, Object>> dataList = objectMapper.readValue(response, new TypeReference<>() {});
+
+			return RegionCode.getValidCodes().stream() // 등록된 모든 지역 코드를 반복
+				.map(code -> {
+					List<Map<String, Object>> regionData = dataList.stream()
+						.filter(item -> code.getSubregion().equals(item.get("C1_NM"))) // 데이터의 C1_NM과 RegionCode의 subregion같은 값을 매칭
+						.collect(Collectors.toList()); // subregion별로 데이터를 모아서 List<Map<String, Object>> 형태로 저장
+
+					if (regionData.isEmpty()) return null; // 데이터가 없으면 null을 리턴 (null인 경우 아래 filter에서 제거됨)
+
+					Map<String, Object> oldest = regionData.stream()
+						.min(Comparator.comparing(item -> (String) item.get("PRD_DE"))).orElse(null); // 가장 오래된 데이터 뽑기
+					Map<String, Object> latest = regionData.stream()
+						.max(Comparator.comparing(item -> (String) item.get("PRD_DE"))).orElse(null); // 가장 최신 데이터 뽑기
+
+					return Map.entry(code,
+						Pair.of(mapToDto(oldest, code), mapToDto(latest, code)));
+				})
+				.filter((Objects::nonNull))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+		} catch (Exception e) {
+			log.warn("KOSIS 데이터 동기화 실패: {}", e.getMessage());
+			throw new CustomException(ErrorCode.EXTERNAL_API_FAILURE);
+		}
+	}
+
+	private ApartmentPriceDto mapToDto(Map<String, Object> entry, RegionCode code) {
+		return ApartmentPriceDto.builder()
+			.region(code.getRegion())
+			.subregion(code.getSubregion())
+			.period((String) entry.get("PRD_DE"))
+			.price(Double.parseDouble((String) entry.get("DT")))
+			.unit((String) entry.get("UNIT_NM"))
+			.build();
 	}
 
 	private String buildUrl(int months) {

--- a/src/main/java/org/example/lifechart/domain/like/repository/LikeRepository.java
+++ b/src/main/java/org/example/lifechart/domain/like/repository/LikeRepository.java
@@ -6,6 +6,7 @@ import org.example.lifechart.domain.like.entity.Like;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,5 +17,9 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
 	@Query("SELECT l.goal.id FROM Like l WHERE l.id = :likeId")
 	Optional<Long> findGoalIdByLikeId(@Param("likeId") Long likeId);
+
+	@Modifying
+	@Query("DELETE FROM Like l WHERE l.goal.id =:goalId")
+	void deleteAllByGoalId(@Param("goalId")Long goalId);
 }
 

--- a/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/CachedApartmentPriceServiceTest.java
@@ -42,13 +42,13 @@ public class CachedApartmentPriceServiceTest {
 			.period("202505")
 			.build();
 
-		given(redisRepository.find(region,subregion)).willReturn(Optional.of(cachedDto));
+		given(redisRepository.findLatest(region,subregion)).willReturn(Optional.of(cachedDto));
 
 		// when
 		Long result = service.getAveragePrice(region, subregion, area);
 
 		// then
-		verify(redisRepository).find(region,subregion);
+		verify(redisRepository).findLatest(region,subregion);
 		assertThat(result).isEqualTo(1500L * 100L * 10_000L);
 	}
 
@@ -67,14 +67,14 @@ public class CachedApartmentPriceServiceTest {
 			.period("202505")
 			.build();
 
-		given(redisRepository.find(region, subregion)).willReturn(Optional.empty());
+		given(redisRepository.findLatest(region, subregion)).willReturn(Optional.empty());
 		given(openApiService.fetchLatest(region, subregion)).willReturn(apiDto);
 
 		// when
 		Long result = service.getAveragePrice(region, subregion, area);
 
 		// then
-		verify(redisRepository).find(region, subregion);
+		verify(redisRepository).findLatest(region, subregion);
 		assertThat(result).isEqualTo(2000L * 50L * 10_000L);
 	}
 
@@ -97,8 +97,8 @@ public class CachedApartmentPriceServiceTest {
 
 		Pair<ApartmentPriceDto, ApartmentPriceDto> pair = Pair.of(start, end);
 
-		given(redisRepository.findStartAndEnd(region, subregion, duration)).willReturn(Optional.of(pair));
-		given(redisRepository.find(region, subregion)).willReturn(Optional.of(end));
+		given(redisRepository.findStartAndEnd(region, subregion)).willReturn(Optional.of(pair));
+		given(redisRepository.findLatest(region, subregion)).willReturn(Optional.of(end));
 
 		// when
 		Long result = service.getFuturePredictedPrice(region, subregion, area, yearsLater);
@@ -107,8 +107,8 @@ public class CachedApartmentPriceServiceTest {
 		double rate = Math.pow(1343.9 / 1000.0, 1.0/10) - 1;
 		Long expected = Math.round(1_343.9 * 100L * 10_000L *Math.pow(1 + rate, 10));
 
-		verify(redisRepository).find(region, subregion);
-		verify(redisRepository).findStartAndEnd(region, subregion, duration);
+		verify(redisRepository).findLatest(region, subregion);
+		verify(redisRepository).findStartAndEnd(region, subregion);
 		assertThat(result).isEqualTo(expected);
 	}
 }

--- a/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/org/example/lifechart/domain/goal/service/GoalServiceImplTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import org.example.lifechart.common.enums.ErrorCode;
 import org.example.lifechart.common.exception.CustomException;
+import org.example.lifechart.domain.comment.repository.CommentRepository;
 import org.example.lifechart.domain.goal.dto.request.*;
 import org.example.lifechart.domain.goal.dto.response.CursorPageResponse;
 import org.example.lifechart.domain.goal.dto.response.GoalDetailInfoResponse;
@@ -36,6 +37,7 @@ import org.example.lifechart.domain.goal.repository.GoalEtcRepository;
 import org.example.lifechart.domain.goal.repository.GoalHousingRepository;
 import org.example.lifechart.domain.goal.repository.GoalRepository;
 import org.example.lifechart.domain.goal.repository.GoalRetirementRepository;
+import org.example.lifechart.domain.like.repository.LikeRepository;
 import org.example.lifechart.domain.user.entity.User;
 import org.example.lifechart.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -75,6 +77,12 @@ public class GoalServiceImplTest {
 	private GoalServiceImpl goalService;
 
 	LocalDateTime fixedNow = LocalDateTime.of(2025,9,1,0,0);
+
+	@Mock
+	private CommentRepository commentRepository;
+
+	@Mock
+	private LikeRepository likeRepository;
 
 	@Test
 	@DisplayName("은퇴 목표 생성에 성공한다.")
@@ -407,6 +415,10 @@ public class GoalServiceImplTest {
 		verify(userRepository).findByIdAndDeletedAtIsNull(user.getId());
 		verify(goalRepository).findByIdAndUserId(goal.getId(), user.getId());
 		assertThat(goal.getStatus()).isEqualTo(Status.DELETED);
+
+		verify(commentRepository).deleteAllByGoalId(goal.getId());
+		verify(likeRepository).deleteAllByGoalId(goal.getId());
+		assertThat(goal.getStatus()).isEqualTo(Status.DELETED);
 	}
 
 	@Test
@@ -437,6 +449,10 @@ public class GoalServiceImplTest {
 		verify(userRepository).findByIdAndDeletedAtIsNull(user.getId());
 		verify(goalRepository).findByIdAndUserId(goal.getId(), user.getId());
 		assertThat(goal.getStatus()).isEqualTo(Status.DELETED);
+
+		verify(commentRepository).deleteAllByGoalId(goal.getId());
+		verify(likeRepository).deleteAllByGoalId(goal.getId());
+		verify(eventPublisher).publishEvent(captor.capture());
 	}
 
 	@Test


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #93 93

## ✨ 변경 사항
[Service]
1. OpenApiApartmentPriceService : API 호출 1번에 Redis 템플릿에 저장하는 메서드 구현 / 최신 데이터 받아오는 메서드 리팩토링
2. CachedApartmentPriceService : 평균 상승률 계산 시 입력으로 받지 않고, 고정된 값으로 반환하는 방식으로 리팩토링

[Scheduler]
1. OpenApiApartmentPriceService의 fetchDurationAll(int year) 메서드를 활용해 데이터를 업데이트 하는 방식으로 변환. 모든 데이터를 저장하는 것이 아닌, 가장 최신, 가장 오래된 데이터만 저장

[Repository]
1. ApartmentPriceCacheRepository : findLatest 메서드 추가, findStartAndEnd 메서드 입력 필드 중 연도 입력 삭제
2. RedisApartmentPriceRepository : 구조 리팩토링. Redis에서 값 읽기/ Redis로 값 쓰기 메서드 구현. 데이터 중 가장 오래된 값, 가장 최신 값을 함께 저장하는 메서드 구현

[Config]
1. RestTemplateConfig : timeout 설정을 위한 SimpleClientHttpRequestFactory 설정 추가

[Common]
1. ApiResponse : 성공 응답 시 ErrorCode 반환 안 하도록 수정

## 📷 Postman 
- OpenApiApartmentPriceServiceTest
![image](https://github.com/user-attachments/assets/057f5cbd-7e11-4a65-bad2-a4e8a632074c)

- CachedApartmentPriceServiceTest
![image](https://github.com/user-attachments/assets/3fe097dc-0098-40e9-b4ab-5f496763f4fc)

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
