### PR TITLE
feature/simulation-module

### DIFF
--- a/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/controller/SimulationController.java
@@ -69,7 +69,7 @@ public class SimulationController {
     @Operation(summary = "시뮬레이션 안에서 업데이트", description = "시뮬레이션에서 목표에 해당하는 계산로직을 수행합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     @PatchMapping("/simulations/{simulationId}")
     public ResponseEntity<ApiResponse<CreateSimulationResponseDto>> updateSimulation(@AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable Long simulationId, @Valid @RequestBody UpdateSimulationRequestDto requestDto) {
-        CreateSimulationResponseDto simulation = simulationService.updateSimulationSettings(principal.getUserId(), simulationId, requestDto  );
+        CreateSimulationResponseDto simulation = simulationService.updateSimulationSettings(principal.getUserId(), simulationId, requestDto );
         return ApiResponse.onSuccess(SuccessCode.SIMULATION_PATCH_SUCCESS, simulation);
     }
 

--- a/src/main/java/org/example/lifechart/domain/simulation/dto/request/UpdateSimulationRequestDto.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/dto/request/UpdateSimulationRequestDto.java
@@ -57,7 +57,5 @@ public class UpdateSimulationRequestDto {
     @NotEmpty(message = "goalIds는 하나 이상의 값을 포함해야 합니다.")
     private List<Long> goalIds;
 
-//    @Schema(description = "시뮬레이션 파라미터", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-//    private SimulationParams params;
 
 }

--- a/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationOnGoalDeletedListener.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationOnGoalDeletedListener.java
@@ -1,5 +1,6 @@
 package org.example.lifechart.domain.simulation.listener;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.lifechart.common.enums.ErrorCode;
@@ -32,6 +33,7 @@ public class SimulationOnGoalDeletedListener {
     private final GoalRepository goalRepository;
     private final GoalRetirementRepository goalRetirementRepository;
 
+    @Transactional
     @EventListener
     public void handleGoalDeletedEvent(GoalDeletedEvent event) {
 

--- a/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationOnGoalDeletedListener.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationOnGoalDeletedListener.java
@@ -15,11 +15,8 @@ import org.example.lifechart.domain.simulation.entity.Simulation;
 import org.example.lifechart.domain.simulation.repository.SimulationGoalRepository;
 import org.example.lifechart.domain.simulation.repository.SimulationRepository;
 import org.example.lifechart.domain.simulation.service.calculator.CalculateAll;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -35,15 +32,14 @@ public class SimulationOnGoalDeletedListener {
     private final GoalRepository goalRepository;
     private final GoalRetirementRepository goalRetirementRepository;
 
-    @Async
-    @Transactional
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleGoalDeletedEvent(GoalDeletedEvent event) {
 
         Long goalId = event.getGoalId();
 
         List<Long> simulationIds = simulationGoalRepository.findSimulationIdsByGoalId(goalId);
 
+        simulationGoalRepository.deleteByGoalId(goalId);
 
         for (Long simulationId : simulationIds) {
 
@@ -81,8 +77,6 @@ public class SimulationOnGoalDeletedListener {
                     expectedDeathDate,
                     selectedGoals
             );
-
-            simulationGoalRepository.deleteByGoalId(goalId);
 
             simulation.updateResults(results);
         }

--- a/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationUpdateListener.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/listener/SimulationUpdateListener.java
@@ -4,10 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.lifechart.domain.goal.event.GoalUpdatedEvent;
 import org.example.lifechart.domain.simulation.service.simulation.SimulationService;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -18,8 +16,7 @@ public class SimulationUpdateListener {
     private final SimulationService simulationService;
 
     //골 로직에서 이벤트 발행하면 이 메서드가 자동으로 실행될 것.
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleGoalUpdatedEvent(GoalUpdatedEvent event) {
 
         System.out.println("GoalUpdatedEvent 수신됨: " + event);

--- a/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
+++ b/src/main/java/org/example/lifechart/domain/simulation/service/simulation/SimulationServiceImpl.java
@@ -198,15 +198,6 @@ public class SimulationServiceImpl implements SimulationService {
     @Transactional
     public void updateSimulationsByGoalChange(Long userId, Long goalId) {
 
-//        MockBankApiResponse<AccountResponse> accountResponse = accountClient.getAccount(userId);
-//        AccountResponse account = accountResponse.getData();
-//
-//        if (accountResponse.getData() == null) {
-//            throw new CustomException(ErrorCode.ACCOUNT_NOT_FOUND);
-//        }
-//
-//        long initialAsset = account.getBalance().longValue();
-
         User user = validUser(userId);
         Goal updateGoal = validGoal(goalId, user.getId());
 
@@ -254,6 +245,8 @@ public class SimulationServiceImpl implements SimulationService {
                     newExpectedDeathDate,
                     relatedGoals
             );
+
+            simulation.updateResults(newResults);
 
             try {
                 eventPublisher.publishUpdateEventByGoalChange(user.getId(), simulation.getId(), updateGoal.getId(), newResults);


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #

## ✨ 변경 사항
- simulationOnGoalDeletedListener에서 먼저 goal이 삭제되어야 이후에  남은 목표 기준으로 시뮬레이션 재계산이 수행되는데 simulationGoalRepository.deleteByGoalId(goalId);
 를 마지막단에 넣어 수행이 안되는 문제를 해결하였습니다
- 현재 이벤트 리스너 @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)를 수행시엔 DB에 업데이트가 안되는 문제점을 확인하여   @EventListener로 수정하였습니다 자세한 문제 원인은 모르겠습니다.. 트랜잭션이 이미 끝난 시점에 수행되는 것이 정확히 어떤 연관성이 있는지 잘 몰라서 계속 알아볼 예정입니다.
-  simulation.updateResults(newResults);가 중간에 삭제가 된 것을 확인하여 다시 추가하였습니다.

## 📷 Postman 
- 이미지 첨부

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
