### PR TITLE
fix: mock 서버 URL을 환경변수 설정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,4 +62,4 @@ aws.key.access.secret=0
 aws.key.access.id=0
 openapi.kosis.key=0
 
-mock-bank.url=http://localhost:8081
+mock-bank.url=${MOCK_BANK_URL:http://localhost:8081}


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #

## ✨ 변경 사항
- mock server url 환경변수 설정하여 EC2에서 설정 후 사용가능하도록 변경
- 기존 로컬에서는 주입하지 않으면 default 값 들어가도록 변경

## 📷 Postman 
- 이미지 첨부

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
