### PR TITLE
[test] : 테스트코드 리팩토링

### DIFF
--- a/src/main/java/org/example/lifechart/domain/comment/service/DistributedLockCommentService.java
+++ b/src/main/java/org/example/lifechart/domain/comment/service/DistributedLockCommentService.java
@@ -21,7 +21,7 @@ public class DistributedLockCommentService {
 	private final CommentService commentService;
 	private final CommentRepository commentRepository;
 	private final String defaultKey = "lock:goal:comment:";
-	private static final long LOCK_WAIT_TIME = 30L;
+	private static final long LOCK_WAIT_TIME = 10L;
 	private static final long LOCK_LEASE_TIME_CREATE = 5L;
 	private static final long LOCK_LEASE_TIME_DELETE = 3L;
 

--- a/src/main/java/org/example/lifechart/domain/like/service/DistributedLockLikeService.java
+++ b/src/main/java/org/example/lifechart/domain/like/service/DistributedLockLikeService.java
@@ -20,8 +20,8 @@ public class DistributedLockLikeService {
 	private final LikeService likeService;
 	private final LikeRepository likeRepository;
 	private final String defaultKey = "lock:goal:like:";
-	private static final long LOCK_WAIT_TIME_PLUS = 50L;
-	private static final long LOCK_WAIT_TIME_DELETE = 30L;
+	private static final long LOCK_WAIT_TIME_PLUS = 10L;
+	private static final long LOCK_WAIT_TIME_DELETE = 10L;
 	private static final long LOCK_LEASE_TIME = 5L;
 
 	public LikeResponseDto plusLike(Long authId, Long goalId) {

--- a/src/test/java/org/example/lifechart/domain/comment/service/DistributedLockCommentServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/comment/service/DistributedLockCommentServiceTest.java
@@ -109,14 +109,14 @@ class DistributedLockCommentServiceTest {
 		List<Long> commentIds = Collections.synchronizedList(new ArrayList<>());
 
 
-		commentLockTest(5000, ()-> {
+		commentLockTest(500, ()-> {
 			Long commentId = distributedLockCommentService.createComment(savedUser.getId(), savedGoal.getId(),
 				commentRequestDto).getId();
 			commentIds.add(commentId);
 		});
 
-		assertEquals(5000, commentIds.size());
-		assertEquals(5000, commentRepository.count());
+		assertEquals(500, commentIds.size());
+		assertEquals(500, commentRepository.count());
 
 
 		commentLockTest(5000, () -> {

--- a/src/test/java/org/example/lifechart/domain/like/service/DistributedLockLikeServiceTest.java
+++ b/src/test/java/org/example/lifechart/domain/like/service/DistributedLockLikeServiceTest.java
@@ -73,7 +73,7 @@ class DistributedLockLikeServiceTest {
 	@BeforeEach
 	void setUp() {
 		userList = new ArrayList<>();
-		for (int i = 0; i < 5000; i++) {
+		for (int i = 0; i < 500; i++) {
 			User user = User.builder()
 				.name(i + "1")
 				.email(i + "1")
@@ -109,7 +109,7 @@ class DistributedLockLikeServiceTest {
 		// likeId도 다 다른 것을 삭제해야 해서 Map 사용
 		Map<Long, Long> userLikeIds = Collections.synchronizedMap(new HashMap<>());
 
-		likeLockTest(5000, () -> {
+		likeLockTest(500, () -> {
 			long userId;
 			synchronized (userList) {
 				if (userList.isEmpty()) {
@@ -124,10 +124,10 @@ class DistributedLockLikeServiceTest {
 			userLikeIds.put(userId, likeId);
 		});
 
-		assertEquals(5000, userLikeIds.size());
-		assertEquals(5000, likeRepository.count());
+		assertEquals(500, userLikeIds.size());
+		assertEquals(500, likeRepository.count());
 
-		likeLockTest(5000, () -> {
+		likeLockTest(500, () -> {
 			Long userId;
 			Long likeId;
 			synchronized (userLikeIds) {


### PR DESCRIPTION
1. 5000명을 병렬로 동시성 제어를 하는 건 부하테스트도 포함된 것 같고, IDE에서 부하 테스트를 하는 건 부적합하다고 하여 500명으로 동시성 제어하도록 변경했습니다.
2. 그에 따라 락을 대기하는 시간을 줄였습니다.

 ## 📌 관련 이슈
- Closes #

## ✨ 변경 사항
- 5000명 -> 500명

## 📷 Postman 
- 이미지 첨부

## ✅ 체크리스트
- [ ] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
